### PR TITLE
Phase 3: 캠페인 상태 관리 + 저장/로드 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,9 @@ RUN chown nobody /app
 
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/trpg_master ./
 
-# Create data directory
+# Create data directories (local dev fallback + Fly volume mount point)
 RUN mkdir -p /app/data && chown nobody:root /app/data
+RUN mkdir -p /data && chown nobody:root /data
 
 USER nobody
 

--- a/fly.toml
+++ b/fly.toml
@@ -9,9 +9,14 @@ kill_signal = 'SIGTERM'
 
 [build]
 
+[mounts]
+  source = "campaign_data"
+  destination = "/data"
+
 [env]
   PHX_HOST = 'trpg-ai-master.fly.dev'
   PORT = '8080'
+  DATA_DIR = '/data'
 
 [http_service]
   internal_port = 8080

--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -1,13 +1,26 @@
 defmodule TrpgMaster.AI.PromptBuilder do
   @moduledoc """
-  시스템 프롬프트 로드 + 대화 히스토리 조립.
-  Phase 1: 기본 시스템 프롬프트 + 전체 히스토리.
+  시스템 프롬프트 로드 + 캠페인 상태 기반 컨텍스트 조립.
   """
 
+  alias TrpgMaster.Campaign.State
+
   @system_prompt_path "priv/prompts/system_dm.md"
+  @max_history_messages 40
 
   @doc """
-  시스템 프롬프트를 로드한다.
+  Campaign.State를 받아서 풍부한 시스템 프롬프트를 조립한다.
+  """
+  def build(%State{} = state) do
+    base = system_prompt()
+    context = build_campaign_context(state)
+    tools_instruction = state_tools_instruction()
+
+    "#{base}\n\n#{context}\n\n#{tools_instruction}"
+  end
+
+  @doc """
+  기본 시스템 프롬프트를 로드한다 (하위 호환).
   """
   def system_prompt do
     case File.read(@system_prompt_path) do
@@ -17,11 +30,132 @@ defmodule TrpgMaster.AI.PromptBuilder do
   end
 
   @doc """
-  대화 히스토리를 Claude API 형식으로 변환한다.
-  Phase 1에서는 단순히 전체 히스토리를 반환한다.
+  대화 히스토리에서 최근 N개만 반환한다 (토큰 예산 관리).
   """
-  def build_messages(conversation_history) do
-    conversation_history
+  def trim_history(history) when length(history) <= @max_history_messages, do: history
+
+  def trim_history(history) do
+    Enum.take(history, -@max_history_messages)
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  defp build_campaign_context(%State{} = state) do
+    sections = [
+      campaign_section(state),
+      characters_section(state),
+      npcs_section(state),
+      quests_section(state),
+      combat_section(state)
+    ]
+
+    sections
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n\n")
+  end
+
+  defp campaign_section(state) do
+    location = state.current_location || "미정"
+
+    """
+    ## 현재 캠페인 상황
+    - 캠페인: #{state.name}
+    - 위치: #{location}
+    - 페이즈: #{state.phase}
+    - 턴: #{state.turn_count}
+    - 모드: #{state.mode}
+    """
+  end
+
+  defp characters_section(%{characters: []}), do: nil
+
+  defp characters_section(state) do
+    chars =
+      state.characters
+      |> Enum.map(fn c ->
+        hp =
+          if c["hp_current"] && c["hp_max"],
+            do: " | HP #{c["hp_current"]}/#{c["hp_max"]}",
+            else: ""
+
+        ac = if c["ac"], do: " | AC #{c["ac"]}", else: ""
+        level = if c["level"], do: " Lv.#{c["level"]}", else: ""
+        class = if c["class"], do: " #{c["class"]}", else: ""
+
+        conditions =
+          case c["conditions"] do
+            list when is_list(list) and list != [] -> " | 상태: #{Enum.join(list, ", ")}"
+            _ -> ""
+          end
+
+        "- #{c["name"]}#{class}#{level}#{hp}#{ac}#{conditions}"
+      end)
+      |> Enum.join("\n")
+
+    "## 캐릭터 정보\n#{chars}"
+  end
+
+  defp npcs_section(%{npcs: npcs}) when map_size(npcs) == 0, do: nil
+
+  defp npcs_section(state) do
+    npcs =
+      state.npcs
+      |> Enum.map(fn {name, data} ->
+        desc = if data["description"], do: " — #{data["description"]}", else: ""
+        disp = if data["disposition"], do: " (#{data["disposition"]})", else: ""
+        loc = if data["location"], do: " @ #{data["location"]}", else: ""
+        "- #{name}#{desc}#{disp}#{loc}"
+      end)
+      |> Enum.join("\n")
+
+    "## 주요 NPC\n#{npcs}"
+  end
+
+  defp quests_section(%{active_quests: []}), do: nil
+
+  defp quests_section(state) do
+    quests =
+      state.active_quests
+      |> Enum.map(fn q ->
+        status = if q["status"], do: " [#{q["status"]}]", else: ""
+        desc = if q["description"], do: " — #{q["description"]}", else: ""
+        "- #{q["name"]}#{status}#{desc}"
+      end)
+      |> Enum.join("\n")
+
+    "## 진행 중인 퀘스트\n#{quests}"
+  end
+
+  defp combat_section(%{combat_state: nil}), do: nil
+
+  defp combat_section(state) do
+    cs = state.combat_state
+    participants = (cs["participants"] || []) |> Enum.join(", ")
+
+    """
+    ## 전투 진행 중
+    - 라운드: #{cs["round"] || 1}
+    - 참가자: #{participants}
+    """
+  end
+
+  defp state_tools_instruction do
+    """
+    ## 상태 관리 도구 사용 지침
+
+    아래 도구들을 사용하여 캠페인 상태를 관리합니다. 상태 변경은 자동으로 저장됩니다.
+
+    - **update_character**: 캐릭터의 HP, 인벤토리, 상태이상 등이 변할 때 반드시 호출합니다.
+      - 전투에서 피해를 입으면 hp_current를 업데이트합니다.
+      - 아이템을 얻거나 잃으면 inventory_add/inventory_remove를 사용합니다.
+    - **register_npc**: 새로운 NPC가 등장하거나 NPC의 태도/상태가 변할 때 호출합니다.
+    - **update_quest**: 새 퀘스트를 발견하거나 진행 상황이 바뀔 때 호출합니다.
+    - **set_location**: 파티가 새로운 장소로 이동할 때 호출합니다.
+    - **start_combat**: 전투가 시작될 때 호출합니다. 그 후 roll_dice로 주도권을 굴립니다.
+    - **end_combat**: 전투가 끝날 때 호출합니다.
+
+    이 도구들을 적극적으로 사용하여 게임 상태를 정확하게 추적하세요.
+    """
   end
 
   defp default_system_prompt do

--- a/lib/trpg_master/ai/tools.ex
+++ b/lib/trpg_master/ai/tools.ex
@@ -125,6 +125,143 @@ defmodule TrpgMaster.AI.Tools do
     }
   end
 
+  # ── State-change tool definitions ────────────────────────────────────────────
+
+  @doc """
+  상태 변경 도구 정의를 반환한다.
+  """
+  def state_tool_definitions do
+    [
+      update_character_def(),
+      register_npc_def(),
+      update_quest_def(),
+      set_location_def(),
+      start_combat_def(),
+      end_combat_def()
+    ]
+  end
+
+  defp update_character_def do
+    %{
+      name: "update_character",
+      description:
+        "캐릭터의 상태를 변경한다. HP 변화, 인벤토리 추가/제거, 주문 슬롯 소모, 상태이상 등. 반드시 변경된 필드만 포함한다.",
+      input_schema: %{
+        type: "object",
+        properties: %{
+          character_name: %{
+            type: "string",
+            description: "대상 캐릭터 이름"
+          },
+          changes: %{
+            type: "object",
+            description:
+              "변경할 필드들. 예: {\"hp_current\": 8, \"inventory_add\": [\"치유 물약\"], \"inventory_remove\": [\"화살\"], \"spell_slots_used\": 1, \"conditions_add\": [\"중독\"], \"conditions_remove\": [\"축복\"]}"
+          }
+        },
+        required: ["character_name", "changes"]
+      }
+    }
+  end
+
+  defp register_npc_def do
+    %{
+      name: "register_npc",
+      description:
+        "새로운 NPC를 등록하거나 기존 NPC 정보를 수정한다. NPC가 처음 등장할 때, 또는 NPC의 상태/태도가 변할 때 호출한다.",
+      input_schema: %{
+        type: "object",
+        properties: %{
+          name: %{type: "string", description: "NPC 이름"},
+          description: %{type: "string", description: "NPC 외모/특징 설명"},
+          disposition: %{
+            type: "string",
+            description: "PC에 대한 태도 (우호적/중립/적대적 등)"
+          },
+          location: %{type: "string", description: "현재 위치"},
+          notes: %{type: "string", description: "기타 메모 (비밀, 목표 등)"}
+        },
+        required: ["name"]
+      }
+    }
+  end
+
+  defp update_quest_def do
+    %{
+      name: "update_quest",
+      description:
+        "퀘스트의 진행 상황을 변경한다. 새 퀘스트 추가, 진행 상태 변경, 완료 처리 등.",
+      input_schema: %{
+        type: "object",
+        properties: %{
+          quest_name: %{type: "string", description: "퀘스트 이름"},
+          status: %{
+            type: "string",
+            description: "진행중 | 완료 | 실패 | 발견"
+          },
+          description: %{type: "string", description: "퀘스트 설명 또는 업데이트 내용"},
+          notes: %{type: "string", description: "추가 메모"}
+        },
+        required: ["quest_name"]
+      }
+    }
+  end
+
+  defp set_location_def do
+    %{
+      name: "set_location",
+      description:
+        "파티의 현재 위치를 변경한다. 새로운 장소에 도착하거나 이동할 때 호출한다.",
+      input_schema: %{
+        type: "object",
+        properties: %{
+          location_name: %{type: "string", description: "위치 이름"},
+          description: %{type: "string", description: "위치 설명"}
+        },
+        required: ["location_name"]
+      }
+    }
+  end
+
+  defp start_combat_def do
+    %{
+      name: "start_combat",
+      description:
+        "전투를 시작한다. 전투 참가자 목록과 함께 호출한다. 이 도구를 호출한 후 각 참가자의 주도권을 roll_dice로 굴린다.",
+      input_schema: %{
+        type: "object",
+        properties: %{
+          participants: %{
+            type: "array",
+            items: %{type: "string"},
+            description: "전투 참가자 이름 목록"
+          }
+        },
+        required: ["participants"]
+      }
+    }
+  end
+
+  defp end_combat_def do
+    %{
+      name: "end_combat",
+      description: "전투를 종료한다. 전리품과 경험치 정보를 포함할 수 있다.",
+      input_schema: %{
+        type: "object",
+        properties: %{
+          loot: %{
+            type: "array",
+            items: %{type: "string"},
+            description: "획득한 전리품 목록"
+          },
+          xp: %{type: "integer", description: "획득 경험치"},
+          summary: %{type: "string", description: "전투 결과 요약"}
+        },
+        required: []
+      }
+    }
+  end
+
   # ── Tool execution ──────────────────────────────────────────────────────────
 
   @doc """
@@ -166,6 +303,42 @@ defmodule TrpgMaster.AI.Tools do
   def execute("lookup_item", input) do
     name = Map.get(input, "name", "")
     lookup_rule(:item, name)
+  end
+
+  # State-change tools: return confirmation, actual state update happens in Campaign.Server
+  def execute("update_character", input) do
+    {:ok, %{"status" => "ok", "message" => "#{input["character_name"]}의 상태가 업데이트되었습니다."}}
+  end
+
+  def execute("register_npc", input) do
+    {:ok, %{"status" => "ok", "message" => "NPC '#{input["name"]}'이(가) 등록/수정되었습니다."}}
+  end
+
+  def execute("update_quest", input) do
+    {:ok,
+     %{
+       "status" => "ok",
+       "message" => "퀘스트 '#{input["quest_name"]}'이(가) 업데이트되었습니다."
+     }}
+  end
+
+  def execute("set_location", input) do
+    {:ok,
+     %{"status" => "ok", "message" => "현재 위치가 '#{input["location_name"]}'(으)로 변경되었습니다."}}
+  end
+
+  def execute("start_combat", input) do
+    participants = input["participants"] || []
+
+    {:ok,
+     %{
+       "status" => "ok",
+       "message" => "전투가 시작되었습니다. 참가자: #{Enum.join(participants, ", ")}"
+     }}
+  end
+
+  def execute("end_combat", _input) do
+    {:ok, %{"status" => "ok", "message" => "전투가 종료되었습니다."}}
   end
 
   def execute(tool_name, _input) do

--- a/lib/trpg_master/application.ex
+++ b/lib/trpg_master/application.ex
@@ -10,6 +10,8 @@ defmodule TrpgMaster.Application do
       {Phoenix.PubSub, name: TrpgMaster.PubSub},
       {DNSCluster, query: Application.get_env(:trpg_master, :dns_cluster_query) || :ignore},
       TrpgMaster.Rules.Loader,
+      {Registry, keys: :unique, name: TrpgMaster.Campaign.Registry},
+      {DynamicSupervisor, name: TrpgMaster.Campaign.Manager, strategy: :one_for_one},
       TrpgMasterWeb.Endpoint
     ]
 

--- a/lib/trpg_master/campaign/manager.ex
+++ b/lib/trpg_master/campaign/manager.ex
@@ -1,0 +1,94 @@
+defmodule TrpgMaster.Campaign.Manager do
+  @moduledoc """
+  캠페인 GenServer 프로세스의 생명주기를 관리한다.
+  DynamicSupervisor를 통해 캠페인 서버를 시작/중지한다.
+  """
+
+  alias TrpgMaster.Campaign.{Server, State, Persistence}
+
+  require Logger
+
+  @doc """
+  새 캠페인을 생성하고 서버를 시작한다.
+  """
+  def create_campaign(name) do
+    id = generate_id()
+
+    state = %State{
+      id: id,
+      name: name
+    }
+
+    case start_server(state) do
+      {:ok, _pid} ->
+        Persistence.save(state)
+        {:ok, id}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  기존 캠페인을 로드하고 서버를 시작한다.
+  이미 실행 중이면 그대로 반환한다.
+  """
+  def start_campaign(campaign_id) do
+    if Server.alive?(campaign_id) do
+      {:ok, campaign_id}
+    else
+      case Persistence.load(campaign_id) do
+        {:ok, state} ->
+          case start_server(state) do
+            {:ok, _pid} -> {:ok, campaign_id}
+            {:error, {:already_started, _pid}} -> {:ok, campaign_id}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, :not_found} ->
+          {:error, :not_found}
+      end
+    end
+  end
+
+  @doc """
+  캠페인 서버를 중지한다.
+  """
+  def stop_campaign(campaign_id) do
+    case Registry.lookup(TrpgMaster.Campaign.Registry, campaign_id) do
+      [{pid, _}] ->
+        # Save before stopping
+        state = Server.get_state(campaign_id)
+        Persistence.save(state)
+        DynamicSupervisor.terminate_child(__MODULE__, pid)
+
+      [] ->
+        :ok
+    end
+  end
+
+  @doc """
+  캠페인을 삭제한다.
+  """
+  def delete_campaign(campaign_id) do
+    stop_campaign(campaign_id)
+    Persistence.delete(campaign_id)
+  end
+
+  @doc """
+  현재 실행 중인 캠페인 ID 목록을 반환한다.
+  """
+  def active_campaigns do
+    Registry.select(TrpgMaster.Campaign.Registry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  defp start_server(%State{} = state) do
+    DynamicSupervisor.start_child(__MODULE__, {Server, state})
+  end
+
+  defp generate_id do
+    :crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)
+  end
+end

--- a/lib/trpg_master/campaign/persistence.ex
+++ b/lib/trpg_master/campaign/persistence.ex
@@ -1,0 +1,235 @@
+defmodule TrpgMaster.Campaign.Persistence do
+  @moduledoc """
+  캠페인 상태를 파일 시스템에 저장하고 로드한다.
+  """
+
+  alias TrpgMaster.Campaign.State
+
+  require Logger
+
+  # ── Public API ──────────────────────────────────────────────────────────────
+
+  @doc """
+  캠페인 상태 전체를 파일에 저장한다.
+  """
+  def save(%State{} = state) do
+    dir = campaign_dir(state.id)
+
+    with :ok <- File.mkdir_p(dir),
+         :ok <- File.mkdir_p(Path.join(dir, "characters")),
+         :ok <- File.mkdir_p(Path.join(dir, "npcs")),
+         :ok <- write_json(Path.join(dir, "campaign-summary.json"), State.to_summary(state)),
+         :ok <- save_characters(dir, state.characters),
+         :ok <- save_npcs(dir, state.npcs),
+         :ok <- write_json(Path.join(dir, "conversation_history.json"), state.conversation_history) do
+      :ok
+    else
+      {:error, reason} ->
+        Logger.error("캠페인 저장 실패 [#{state.id}]: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  비동기로 캠페인 상태를 저장한다 (응답 지연 방지).
+  """
+  def save_async(%State{} = state) do
+    Task.start(fn ->
+      case save(state) do
+        :ok -> :ok
+        {:error, reason} -> Logger.error("비동기 캠페인 저장 실패: #{inspect(reason)}")
+      end
+    end)
+  end
+
+  @doc """
+  캠페인을 파일에서 로드한다.
+  """
+  def load(campaign_id) do
+    dir = campaign_dir(campaign_id)
+    summary_path = Path.join(dir, "campaign-summary.json")
+
+    if File.exists?(summary_path) do
+      with {:ok, summary} <- read_json(summary_path),
+           {:ok, characters} <- load_characters(dir),
+           {:ok, npcs} <- load_npcs(dir),
+           {:ok, history} <- load_conversation_history(dir) do
+        state =
+          State.from_summary(summary)
+          |> Map.put(:characters, characters)
+          |> Map.put(:npcs, npcs)
+          |> Map.put(:conversation_history, history)
+
+        {:ok, state}
+      end
+    else
+      {:error, :not_found}
+    end
+  end
+
+  @doc """
+  저장된 캠페인 목록을 반환한다 (최근 업데이트 순).
+  """
+  def list_campaigns do
+    campaigns_dir = Path.join(data_dir(), "campaigns")
+
+    if File.exists?(campaigns_dir) do
+      case File.ls(campaigns_dir) do
+        {:ok, dirs} ->
+          dirs
+          |> Enum.map(fn dir_name ->
+            summary_path = Path.join([campaigns_dir, dir_name, "campaign-summary.json"])
+
+            case read_json(summary_path) do
+              {:ok, summary} ->
+                %{
+                  id: summary["id"],
+                  name: summary["name"],
+                  updated_at: summary["updated_at"]
+                }
+
+              _ ->
+                nil
+            end
+          end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.sort_by(& &1.updated_at, :desc)
+
+        _ ->
+          []
+      end
+    else
+      []
+    end
+  end
+
+  @doc """
+  캠페인 데이터를 삭제한다.
+  """
+  def delete(campaign_id) do
+    dir = campaign_dir(campaign_id)
+
+    if File.exists?(dir) do
+      File.rm_rf(dir)
+      :ok
+    else
+      :ok
+    end
+  end
+
+  # ── Private helpers ─────────────────────────────────────────────────────────
+
+  defp data_dir do
+    Application.get_env(:trpg_master, :data_dir, "data")
+  end
+
+  defp campaign_dir(campaign_id) do
+    Path.join([data_dir(), "campaigns", sanitize_filename(campaign_id)])
+  end
+
+  defp sanitize_filename(name) do
+    name
+    |> String.replace(~r/[\/\\:*?"<>|]/, "_")
+    |> String.trim()
+  end
+
+  defp write_json(path, data) do
+    case Jason.encode(data, pretty: true) do
+      {:ok, json} -> File.write(path, json)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp read_json(path) do
+    with {:ok, content} <- File.read(path),
+         {:ok, data} <- Jason.decode(content) do
+      {:ok, data}
+    end
+  end
+
+  defp save_characters(dir, characters) do
+    Enum.each(characters, fn char ->
+      name = char["name"] || "unknown"
+      path = Path.join([dir, "characters", "#{sanitize_filename(name)}.json"])
+      write_json(path, char)
+    end)
+
+    :ok
+  end
+
+  defp save_npcs(dir, npcs) do
+    Enum.each(npcs, fn {name, data} ->
+      path = Path.join([dir, "npcs", "#{sanitize_filename(name)}.json"])
+      write_json(path, data)
+    end)
+
+    :ok
+  end
+
+  defp load_characters(dir) do
+    chars_dir = Path.join(dir, "characters")
+
+    if File.exists?(chars_dir) do
+      case File.ls(chars_dir) do
+        {:ok, files} ->
+          characters =
+            files
+            |> Enum.filter(&String.ends_with?(&1, ".json"))
+            |> Enum.map(fn file ->
+              case read_json(Path.join(chars_dir, file)) do
+                {:ok, data} -> data
+                _ -> nil
+              end
+            end)
+            |> Enum.reject(&is_nil/1)
+
+          {:ok, characters}
+
+        _ ->
+          {:ok, []}
+      end
+    else
+      {:ok, []}
+    end
+  end
+
+  defp load_npcs(dir) do
+    npcs_dir = Path.join(dir, "npcs")
+
+    if File.exists?(npcs_dir) do
+      case File.ls(npcs_dir) do
+        {:ok, files} ->
+          npcs =
+            files
+            |> Enum.filter(&String.ends_with?(&1, ".json"))
+            |> Enum.reduce(%{}, fn file, acc ->
+              case read_json(Path.join(npcs_dir, file)) do
+                {:ok, data} ->
+                  name = data["name"] || Path.rootname(file)
+                  Map.put(acc, name, data)
+
+                _ ->
+                  acc
+              end
+            end)
+
+          {:ok, npcs}
+
+        _ ->
+          {:ok, %{}}
+      end
+    else
+      {:ok, %{}}
+    end
+  end
+
+  defp load_conversation_history(dir) do
+    path = Path.join(dir, "conversation_history.json")
+
+    if File.exists?(path) do
+      read_json(path)
+    else
+      {:ok, []}
+    end
+  end
+end

--- a/lib/trpg_master/campaign/server.ex
+++ b/lib/trpg_master/campaign/server.ex
@@ -1,0 +1,204 @@
+defmodule TrpgMaster.Campaign.Server do
+  @moduledoc """
+  캠페인 하나 = GenServer 프로세스 하나.
+  플레이어 메시지 처리, 상태 관리, AI 호출을 담당한다.
+  """
+
+  use GenServer
+
+  alias TrpgMaster.Campaign.{State, Persistence}
+  alias TrpgMaster.AI.{Client, PromptBuilder, Tools}
+
+  require Logger
+
+  # ── Public API ──────────────────────────────────────────────────────────────
+
+  def start_link(%State{} = state) do
+    GenServer.start_link(__MODULE__, state, name: via(state.id))
+  end
+
+  def player_action(campaign_id, message) do
+    GenServer.call(via(campaign_id), {:player_action, message}, 180_000)
+  end
+
+  def get_state(campaign_id) do
+    GenServer.call(via(campaign_id), :get_state)
+  end
+
+  def alive?(campaign_id) do
+    case Registry.lookup(TrpgMaster.Campaign.Registry, campaign_id) do
+      [{_pid, _}] -> true
+      [] -> false
+    end
+  end
+
+  # ── GenServer Callbacks ─────────────────────────────────────────────────────
+
+  @impl true
+  def init(%State{} = state) do
+    Logger.info("캠페인 서버 시작: #{state.name} [#{state.id}]")
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  def handle_call({:player_action, message}, _from, state) do
+    # 1. Add player message to conversation history
+    history = state.conversation_history ++ [%{"role" => "user", "content" => message}]
+    state = %{state | conversation_history: history, turn_count: state.turn_count + 1}
+
+    # 2. Build system prompt with campaign context
+    system_prompt = PromptBuilder.build(state)
+
+    # 3. Build tools list (existing + state-change tools)
+    tools = Tools.definitions() ++ Tools.state_tool_definitions()
+
+    # 4. Call AI (trim history for token budget)
+    trimmed_history = PromptBuilder.trim_history(history)
+
+    case Client.chat(system_prompt, trimmed_history, tools) do
+      {:ok, result} ->
+        # 5. Process state-change tool results
+        state = apply_tool_results(state, result.tool_results)
+
+        # 6. Add assistant response to conversation history
+        state = %{
+          state
+          | conversation_history:
+              state.conversation_history ++ [%{"role" => "assistant", "content" => result.text}]
+        }
+
+        # 7. Save async
+        Persistence.save_async(state)
+
+        {:reply, {:ok, result}, state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  # ── Private helpers ─────────────────────────────────────────────────────────
+
+  defp via(campaign_id) do
+    {:via, Registry, {TrpgMaster.Campaign.Registry, campaign_id}}
+  end
+
+  defp apply_tool_results(state, tool_results) do
+    Enum.reduce(tool_results, state, fn result, acc ->
+      apply_single_tool_result(acc, result)
+    end)
+  end
+
+  defp apply_single_tool_result(state, %{tool: "update_character", input: input}) do
+    char_name = input["character_name"]
+    changes = input["changes"] || %{}
+
+    characters =
+      case Enum.find_index(state.characters, &(&1["name"] == char_name)) do
+        nil ->
+          # Character doesn't exist, create it
+          [Map.merge(%{"name" => char_name}, changes) | state.characters]
+
+        idx ->
+          List.update_at(state.characters, idx, fn char ->
+            char
+            |> apply_character_changes(changes)
+          end)
+      end
+
+    %{state | characters: characters}
+  end
+
+  defp apply_single_tool_result(state, %{tool: "register_npc", input: input}) do
+    name = input["name"]
+
+    npc_data =
+      Map.merge(
+        Map.get(state.npcs, name, %{}),
+        input |> Map.drop(["name"]) |> Map.reject(fn {_k, v} -> is_nil(v) end)
+      )
+      |> Map.put("name", name)
+
+    %{state | npcs: Map.put(state.npcs, name, npc_data)}
+  end
+
+  defp apply_single_tool_result(state, %{tool: "update_quest", input: input}) do
+    quest_name = input["quest_name"]
+
+    quests =
+      case Enum.find_index(state.active_quests, &(&1["name"] == quest_name)) do
+        nil ->
+          state.active_quests ++
+            [
+              %{
+                "name" => quest_name,
+                "status" => input["status"] || "발견",
+                "description" => input["description"],
+                "notes" => input["notes"]
+              }
+            ]
+
+        idx ->
+          List.update_at(state.active_quests, idx, fn quest ->
+            quest
+            |> maybe_put("status", input["status"])
+            |> maybe_put("description", input["description"])
+            |> maybe_put("notes", input["notes"])
+          end)
+      end
+
+    %{state | active_quests: quests}
+  end
+
+  defp apply_single_tool_result(state, %{tool: "set_location", input: input}) do
+    %{state | current_location: input["location_name"]}
+  end
+
+  defp apply_single_tool_result(state, %{tool: "start_combat", input: input}) do
+    combat = %{
+      "participants" => input["participants"] || [],
+      "round" => 1,
+      "turn_order" => []
+    }
+
+    %{state | phase: :combat, combat_state: combat}
+  end
+
+  defp apply_single_tool_result(state, %{tool: "end_combat", input: _input}) do
+    %{state | phase: :exploration, combat_state: nil}
+  end
+
+  defp apply_single_tool_result(state, _result), do: state
+
+  defp apply_character_changes(char, changes) do
+    char
+    |> maybe_put("hp_current", changes["hp_current"])
+    |> maybe_put("hp_max", changes["hp_max"])
+    |> maybe_put("class", changes["class"])
+    |> maybe_put("level", changes["level"])
+    |> maybe_put("ac", changes["ac"])
+    |> maybe_put("spell_slots_used", changes["spell_slots_used"])
+    |> apply_list_change("inventory", changes["inventory_add"], changes["inventory_remove"])
+    |> apply_list_change("conditions", changes["conditions_add"], changes["conditions_remove"])
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp apply_list_change(map, key, add, remove) do
+    current = Map.get(map, key, [])
+
+    current =
+      if is_list(add), do: current ++ add, else: current
+
+    current =
+      if is_list(remove), do: current -- remove, else: current
+
+    Map.put(map, key, current)
+  end
+end

--- a/lib/trpg_master/campaign/state.ex
+++ b/lib/trpg_master/campaign/state.ex
@@ -1,0 +1,68 @@
+defmodule TrpgMaster.Campaign.State do
+  @moduledoc """
+  캠페인의 전체 상태를 담는 구조체.
+  """
+
+  defstruct [
+    :id,
+    :name,
+    phase: :exploration,
+    characters: [],
+    npcs: %{},
+    current_location: nil,
+    active_quests: [],
+    combat_state: nil,
+    conversation_history: [],
+    turn_count: 0,
+    mode: :adventure
+  ]
+
+  @doc """
+  State 구조체를 직렬화 가능한 맵으로 변환한다.
+  """
+  def to_summary(%__MODULE__{} = state) do
+    %{
+      "id" => state.id,
+      "name" => state.name,
+      "phase" => to_string(state.phase),
+      "current_location" => state.current_location,
+      "active_quests" => state.active_quests,
+      "turn_count" => state.turn_count,
+      "mode" => to_string(state.mode),
+      "combat_state" => state.combat_state,
+      "updated_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+  end
+
+  @doc """
+  summary 맵에서 State 구조체를 복원한다.
+  characters, npcs, conversation_history는 별도로 로드한다.
+  """
+  def from_summary(summary) do
+    %__MODULE__{
+      id: summary["id"],
+      name: summary["name"],
+      phase: safe_atom(summary["phase"], :exploration),
+      current_location: summary["current_location"],
+      active_quests: summary["active_quests"] || [],
+      turn_count: summary["turn_count"] || 0,
+      mode: safe_atom(summary["mode"], :adventure),
+      combat_state: summary["combat_state"]
+    }
+  end
+
+  defp safe_atom(nil, default), do: default
+  defp safe_atom(value, _default) when is_atom(value), do: value
+
+  defp safe_atom(value, default) when is_binary(value) do
+    case value do
+      "exploration" -> :exploration
+      "combat" -> :combat
+      "dialogue" -> :dialogue
+      "rest" -> :rest
+      "adventure" -> :adventure
+      "debug" -> :debug
+      _ -> default
+    end
+  end
+end

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -3,17 +3,35 @@ defmodule TrpgMasterWeb.CampaignLive do
 
   import TrpgMasterWeb.GameComponents
 
-  alias TrpgMaster.AI.{Client, PromptBuilder, Tools}
+  alias TrpgMaster.Campaign.{Manager, Server}
 
   @impl true
-  def mount(_params, _session, socket) do
-    {:ok,
-     socket
-     |> assign(:messages, [])
-     |> assign(:conversation_history, [])
-     |> assign(:input_text, "")
-     |> assign(:loading, false)
-     |> assign(:error, nil)}
+  def mount(%{"id" => campaign_id}, _session, socket) do
+    # Ensure the campaign server is running
+    case Manager.start_campaign(campaign_id) do
+      {:ok, _id} ->
+        state = Server.get_state(campaign_id)
+
+        # Build display messages from conversation history
+        messages = build_display_messages(state.conversation_history)
+
+        {:ok,
+         socket
+         |> assign(:campaign_id, campaign_id)
+         |> assign(:campaign_name, state.name)
+         |> assign(:messages, messages)
+         |> assign(:input_text, "")
+         |> assign(:loading, false)
+         |> assign(:error, nil)
+         |> assign(:current_location, state.current_location)
+         |> assign(:phase, state.phase)}
+
+      {:error, :not_found} ->
+        {:ok,
+         socket
+         |> put_flash(:error, "캠페인을 찾을 수 없습니다.")
+         |> push_navigate(to: "/")}
+    end
   end
 
   @impl true
@@ -23,23 +41,18 @@ defmodule TrpgMasterWeb.CampaignLive do
     if message == "" do
       {:noreply, socket}
     else
-      # Add player message to display
+      # Add player message to display immediately
       messages = socket.assigns.messages ++ [%{type: :player, text: message}]
-
-      # Add to conversation history (Claude API format)
-      conversation_history =
-        socket.assigns.conversation_history ++ [%{role: "user", content: message}]
 
       socket =
         socket
         |> assign(:messages, messages)
-        |> assign(:conversation_history, conversation_history)
         |> assign(:input_text, "")
         |> assign(:loading, true)
         |> assign(:error, nil)
 
-      # Trigger async AI call
-      send(self(), {:call_ai, conversation_history})
+      # Trigger async AI call via GenServer
+      send(self(), {:call_ai, message})
 
       {:noreply, socket}
     end
@@ -50,32 +63,35 @@ defmodule TrpgMasterWeb.CampaignLive do
   end
 
   @impl true
-  def handle_info({:call_ai, conversation_history}, socket) do
-    system_prompt = PromptBuilder.system_prompt()
-    tools = Tools.definitions()
+  def handle_info({:call_ai, message}, socket) do
+    campaign_id = socket.assigns.campaign_id
 
-    case Client.chat(system_prompt, conversation_history, tools) do
+    case Server.player_action(campaign_id, message) do
       {:ok, result} ->
         # Add tool results to display
         messages =
           Enum.reduce(result.tool_results, socket.assigns.messages, fn tool_result, acc ->
             case tool_result do
-              %{result: dice_result} -> acc ++ [%{type: :dice, result: dice_result}]
-              _ -> acc
+              %{result: %{"formatted" => _} = dice_result} ->
+                acc ++ [%{type: :dice, result: dice_result}]
+
+              _ ->
+                acc
             end
           end)
 
         # Add DM response to display
         messages = messages ++ [%{type: :dm, text: result.text}]
 
-        # Add assistant response to conversation history
-        updated_history = conversation_history ++ [%{role: "assistant", content: result.text}]
+        # Get updated state for sidebar info
+        state = Server.get_state(campaign_id)
 
         {:noreply,
          socket
          |> assign(:messages, messages)
-         |> assign(:conversation_history, updated_history)
-         |> assign(:loading, false)}
+         |> assign(:loading, false)
+         |> assign(:current_location, state.current_location)
+         |> assign(:phase, state.phase)}
 
       {:error, reason} ->
         {:noreply,
@@ -90,8 +106,14 @@ defmodule TrpgMasterWeb.CampaignLive do
     ~H"""
     <div class="game-container">
       <header class="game-header">
-        <h1>AI TRPG Master</h1>
-        <span class="mode-badge">모험 모드</span>
+        <div class="header-left">
+          <a href="/" class="back-link">←</a>
+          <h1><%= @campaign_name %></h1>
+        </div>
+        <div class="header-right">
+          <span :if={@current_location} class="location-badge"><%= @current_location %></span>
+          <span class="mode-badge"><%= phase_label(@phase) %></span>
+        </div>
       </header>
 
       <div class="chat-area" id="chat-area" phx-hook="ScrollBottom">
@@ -141,4 +163,28 @@ defmodule TrpgMasterWeb.CampaignLive do
     </div>
     """
   end
+
+  # ── Private helpers ─────────────────────────────────────────────────────────
+
+  defp build_display_messages(conversation_history) do
+    conversation_history
+    |> Enum.reduce([], fn msg, acc ->
+      case msg do
+        %{"role" => "user", "content" => content} when is_binary(content) ->
+          acc ++ [%{type: :player, text: content}]
+
+        %{"role" => "assistant", "content" => content} when is_binary(content) ->
+          acc ++ [%{type: :dm, text: content}]
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp phase_label(:exploration), do: "탐험"
+  defp phase_label(:combat), do: "전투"
+  defp phase_label(:dialogue), do: "대화"
+  defp phase_label(:rest), do: "휴식"
+  defp phase_label(_), do: "모험"
 end

--- a/lib/trpg_master_web/live/lobby_live.ex
+++ b/lib/trpg_master_web/live/lobby_live.ex
@@ -1,0 +1,107 @@
+defmodule TrpgMasterWeb.LobbyLive do
+  use TrpgMasterWeb, :live_view
+
+  alias TrpgMaster.Campaign.{Manager, Persistence}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    campaigns = Persistence.list_campaigns()
+
+    {:ok,
+     socket
+     |> assign(:campaigns, campaigns)
+     |> assign(:new_name, "")
+     |> assign(:error, nil)}
+  end
+
+  @impl true
+  def handle_event("create_campaign", %{"name" => name}, socket) do
+    name = String.trim(name)
+
+    if name == "" do
+      {:noreply, assign(socket, :error, "캠페인 이름을 입력하세요.")}
+    else
+      case Manager.create_campaign(name) do
+        {:ok, id} ->
+          {:noreply, push_navigate(socket, to: "/play/#{id}")}
+
+        {:error, reason} ->
+          {:noreply, assign(socket, :error, "생성 실패: #{inspect(reason)}")}
+      end
+    end
+  end
+
+  @impl true
+  def handle_event("delete_campaign", %{"id" => id}, socket) do
+    Manager.delete_campaign(id)
+    campaigns = Persistence.list_campaigns()
+    {:noreply, assign(socket, :campaigns, campaigns)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="lobby-container">
+      <header class="lobby-header">
+        <h1>AI TRPG Master</h1>
+        <p class="lobby-subtitle">D&D 5e Solo Play</p>
+      </header>
+
+      <div class="lobby-content">
+        <section class="new-campaign">
+          <h2>새 캠페인 시작</h2>
+          <form phx-submit="create_campaign" class="new-campaign-form">
+            <input
+              type="text"
+              name="name"
+              value={@new_name}
+              placeholder="캠페인 이름을 입력하세요"
+              autocomplete="off"
+            />
+            <button type="submit">시작</button>
+          </form>
+          <%= if @error do %>
+            <p class="lobby-error"><%= @error %></p>
+          <% end %>
+        </section>
+
+        <%= if @campaigns != [] do %>
+          <section class="campaign-list">
+            <h2>저장된 캠페인</h2>
+            <div class="campaigns">
+              <%= for campaign <- @campaigns do %>
+                <div class="campaign-card">
+                  <a href={"/play/#{campaign.id}"} class="campaign-link">
+                    <span class="campaign-name"><%= campaign.name %></span>
+                    <span class="campaign-date"><%= format_date(campaign.updated_at) %></span>
+                  </a>
+                  <button
+                    class="campaign-delete"
+                    phx-click="delete_campaign"
+                    phx-value-id={campaign.id}
+                    data-confirm="정말 삭제하시겠습니까?"
+                  >
+                    삭제
+                  </button>
+                </div>
+              <% end %>
+            </div>
+          </section>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp format_date(nil), do: ""
+
+  defp format_date(date_str) when is_binary(date_str) do
+    case DateTime.from_iso8601(date_str) do
+      {:ok, dt, _} ->
+        Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+
+      _ ->
+        date_str
+    end
+  end
+end

--- a/lib/trpg_master_web/router.ex
+++ b/lib/trpg_master_web/router.ex
@@ -13,6 +13,7 @@ defmodule TrpgMasterWeb.Router do
   scope "/", TrpgMasterWeb do
     pipe_through :browser
 
-    live "/", CampaignLive, :index
+    live "/", LobbyLive, :index
+    live "/play/:id", CampaignLive, :play
   end
 end

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -337,6 +337,184 @@ html, body {
   }
 }
 
+/* Lobby */
+.lobby-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: 100dvh;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  overflow-y: auto;
+}
+
+.lobby-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.lobby-header h1 {
+  font-size: 1.8rem;
+  color: var(--accent-gold);
+  margin-bottom: 0.25rem;
+}
+
+.lobby-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.lobby-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.new-campaign h2,
+.campaign-list h2 {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.new-campaign-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.new-campaign-form input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 1rem;
+  outline: none;
+}
+
+.new-campaign-form input:focus {
+  border-color: var(--accent-blue);
+}
+
+.new-campaign-form input::placeholder {
+  color: var(--text-secondary);
+}
+
+.new-campaign-form button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 12px;
+  border: none;
+  background: var(--accent-gold);
+  color: var(--bg-primary);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.new-campaign-form button:hover {
+  opacity: 0.9;
+}
+
+.lobby-error {
+  color: var(--accent-red);
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.campaigns {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.campaign-card {
+  display: flex;
+  align-items: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.campaign-card:hover {
+  border-color: var(--accent-gold);
+}
+
+.campaign-link {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.campaign-name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.campaign-date {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.campaign-delete {
+  padding: 0.5rem 0.75rem;
+  margin-right: 0.5rem;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.campaign-delete:hover {
+  background: rgba(231, 76, 60, 0.2);
+  color: var(--accent-red);
+}
+
+/* Game header with back link */
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.back-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 1.2rem;
+  padding: 0.2rem 0.4rem;
+}
+
+.back-link:hover {
+  color: var(--accent-gold);
+}
+
+.location-badge {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  background: rgba(46, 204, 113, 0.15);
+  color: var(--accent-green);
+  border: 1px solid rgba(46, 204, 113, 0.3);
+}
+
 /* Safe area for notched phones */
 @supports (padding-bottom: env(safe-area-inset-bottom)) {
   .input-area {


### PR DESCRIPTION
캠페인을 생성·저장·로드하여 서버 재시작 후에도 이어서 플레이할 수 있게 한다.

새 모듈:
- Campaign.State: 캠페인 전체 상태 구조체 (캐릭터, NPC, 퀘스트, 전투 등)
- Campaign.Persistence: 파일 시스템 기반 저장/로드 (DATA_DIR 환경변수)
- Campaign.Server: GenServer로 캠페인별 상태 관리 + AI 호출
- Campaign.Manager: DynamicSupervisor로 캠페인 생명주기 관리
- LobbyLive: 캠페인 목록/생성/삭제 로비 UI

변경된 모듈:
- AI.Tools: 상태 변경 도구 6개 추가 (update_character, register_npc,
  update_quest, set_location, start_combat, end_combat)
- AI.PromptBuilder: State 기반 동적 컨텍스트 조립 + 히스토리 트리밍
- CampaignLive: GenServer 연동, URL 파라미터로 캠페인 로드
- Router: / → LobbyLive, /play/:id → CampaignLive
- Application: Registry + DynamicSupervisor 추가
- fly.toml: 볼륨 마운트 + DATA_DIR 설정
- Dockerfile: /data 디렉토리 생성

https://claude.ai/code/session_01WjRsR9LLKTnFemU1QyEFbQ