### PR TITLE
토큰 절약을 위해 대화 히스토리 제한을 40에서 20으로 축소

### DIFF
--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -6,7 +6,7 @@ defmodule TrpgMaster.AI.PromptBuilder do
   alias TrpgMaster.Campaign.State
 
   @system_prompt_path "priv/prompts/system_dm.md"
-  @max_history_messages 40
+  @max_history_messages 20
 
   @doc """
   Campaign.State를 받아서 풍부한 시스템 프롬프트를 조립한다.


### PR DESCRIPTION
API 429 rate limit 에러 방지를 위해 매 요청마다 전송되는
입력 토큰 수를 줄임.

https://claude.ai/code/session_01WjRsR9LLKTnFemU1QyEFbQ