### PR TITLE
Phase 3 버그 수정 + Phase 4: 컨텍스트 최적화 + 상태바 UI

### DIFF
--- a/lib/trpg_master/ai/client.ex
+++ b/lib/trpg_master/ai/client.ex
@@ -14,19 +14,26 @@ defmodule TrpgMaster.AI.Client do
   Claude API에 메시지를 보내고 응답을 받는다.
   tool use가 발생하면 도구를 실행하고 자동으로 재호출한다.
 
+  옵션:
+    - model: 사용할 Claude 모델 (기본값: 설정된 모델)
+    - max_tokens: 최대 출력 토큰 (기본값: 4096)
+
   반환값:
     {:ok, %{text: String.t(), tool_results: [map()], usage: map()}}
     {:error, term()}
   """
-  def chat(system_prompt, messages, tools \\ []) do
+  def chat(system_prompt, messages, tools \\ [], opts \\ []) do
     api_key = Application.get_env(:trpg_master, :anthropic_api_key)
 
     if is_nil(api_key) || api_key == "" do
       {:error, "ANTHROPIC_API_KEY가 설정되지 않았습니다"}
     else
+      selected_model = Keyword.get(opts, :model, model())
+      max_tokens = Keyword.get(opts, :max_tokens, 4096)
+
       body = %{
-        model: model(),
-        max_tokens: 4096,
+        model: selected_model,
+        max_tokens: max_tokens,
         system: system_prompt,
         messages: messages,
         tools: tools

--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -6,7 +6,12 @@ defmodule TrpgMaster.AI.PromptBuilder do
   alias TrpgMaster.Campaign.State
 
   @system_prompt_path "priv/prompts/system_dm.md"
-  @max_history_messages 20
+
+  # 토큰 예산 (한국어 위주: ~1토큰/2문자 보수적 추정)
+  # Claude Sonnet 기준 200K 컨텍스트에서 응답 4K 예약, 시스템 프롬프트 10K 예약 후 남은 예산
+  @max_history_tokens 40_000
+
+  require Logger
 
   @doc """
   Campaign.State를 받아서 풍부한 시스템 프롬프트를 조립한다.
@@ -30,13 +35,61 @@ defmodule TrpgMaster.AI.PromptBuilder do
   end
 
   @doc """
-  대화 히스토리에서 최근 N개만 반환한다 (토큰 예산 관리).
+  토큰 예산 기반으로 대화 히스토리를 트리밍한다.
+  최근 메시지를 최대한 많이 포함하되 @max_history_tokens 예산 초과 시 오래된 것부터 제거.
   """
-  def trim_history(history) when length(history) <= @max_history_messages, do: history
+  def build_messages(history) when is_list(history) do
+    total = estimate_tokens(history)
 
-  def trim_history(history) do
-    Enum.take(history, -@max_history_messages)
+    if total <= @max_history_tokens do
+      history
+    else
+      # 최근 메시지부터 역순으로 누적하여 예산 내 메시지만 선택
+      {recent, _remaining} =
+        history
+        |> Enum.reverse()
+        |> Enum.reduce_while({[], @max_history_tokens}, fn msg, {acc, remaining} ->
+          tokens = estimate_tokens_msg(msg) + 10
+          if tokens <= remaining do
+            {:cont, {[msg | acc], remaining - tokens}}
+          else
+            {:halt, {acc, 0}}
+          end
+        end)
+
+      trimmed_count = length(history) - length(recent)
+
+      if trimmed_count > 0 do
+        Logger.info(
+          "히스토리 트리밍: #{length(history)}개 → #{length(recent)}개 (#{trimmed_count}개 제거, 추정 토큰: #{total})"
+        )
+      end
+
+      recent
+    end
   end
+
+  @doc """
+  하위 호환: trim_history/1은 build_messages/1로 대체됨.
+  """
+  def trim_history(history), do: build_messages(history)
+
+  # ── Token estimation ────────────────────────────────────────────────────────
+
+  # 한국어 위주 혼합 텍스트: 보수적으로 1토큰/2문자 추정
+  defp estimate_tokens(text) when is_binary(text) do
+    div(String.length(text), 2)
+  end
+
+  defp estimate_tokens(messages) when is_list(messages) do
+    Enum.sum(Enum.map(messages, &(estimate_tokens_msg(&1) + 10)))
+  end
+
+  defp estimate_tokens_msg(%{"content" => content}) when is_binary(content) do
+    estimate_tokens(content)
+  end
+
+  defp estimate_tokens_msg(_), do: 10
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
@@ -141,21 +194,28 @@ defmodule TrpgMaster.AI.PromptBuilder do
 
   defp state_tools_instruction do
     """
-    ## 상태 관리 도구 사용 지침
+    ## ⚠️ 중요: 상태 관리 도구를 반드시 사용하세요
 
-    아래 도구들을 사용하여 캠페인 상태를 관리합니다. 상태 변경은 자동으로 저장됩니다.
+    서버는 당신이 도구를 호출한 결과만 기억합니다. 도구를 호출하지 않으면 다음 턴에서 정보를 잃습니다.
 
-    - **update_character**: 캐릭터가 처음 등장하거나, HP/인벤토리/상태이상 등이 변할 때 반드시 호출합니다.
-      - ⚠️ 플레이어 캐릭터가 소개되면 즉시 호출하여 초기 스탯(이름, 클래스, 레벨, hp_max, hp_current, ac, 초기 장비)을 등록합니다.
-      - 전투에서 피해를 입으면 hp_current를 업데이트합니다.
-      - 아이템을 얻거나 잃으면 inventory_add/inventory_remove를 사용합니다.
-    - **register_npc**: 새로운 NPC가 등장하거나 NPC의 태도/상태가 변할 때 호출합니다.
-    - **update_quest**: 새 퀘스트를 발견하거나 진행 상황이 바뀔 때 호출합니다.
-    - **set_location**: 파티가 새로운 장소로 이동할 때 호출합니다.
-    - **start_combat**: 전투가 시작될 때 호출합니다. 그 후 roll_dice로 주도권을 굴립니다.
-    - **end_combat**: 전투가 끝날 때 호출합니다.
+    ### 필수 규칙 (예외 없음)
 
-    이 도구들을 적극적으로 사용하여 게임 상태를 정확하게 추적하세요.
+    - **새로운 NPC가 등장하면 → 반드시 register_npc를 즉시 호출**
+      - 이름, 외모, 성격, 태도(friendly/neutral/hostile), 위치를 기록합니다
+      - 당신이 register_npc를 호출하지 않으면 서버가 이 NPC를 전혀 기억하지 못합니다
+      - 다음 턴에서 플레이어가 NPC를 언급해도 당신은 기억하지 못하게 됩니다
+    - **캐릭터 HP/아이템/상태가 변하면 → 반드시 update_character를 호출**
+      - 플레이어 캐릭터가 처음 소개되면 즉시 초기 스탯을 등록합니다
+      - 전투 피해 → hp_current 업데이트
+      - 아이템 획득/소실 → inventory_add/inventory_remove
+    - **파티가 이동하면 → 반드시 set_location을 호출**
+    - **새 퀘스트 발견 또는 진행 → 반드시 update_quest를 호출**
+    - **전투 시작 → start_combat, 전투 종료 → end_combat**
+
+    ### 도구 미사용 결과
+    도구를 호출하지 않고 서술만 하면: 서버가 해당 정보를 저장하지 않습니다.
+    다음 턴에서 당신은 그 정보를 시스템 프롬프트에서 볼 수 없게 됩니다.
+    일관성 있는 게임 진행을 위해 모든 상태 변경을 반드시 도구로 기록하세요.
     """
   end
 

--- a/lib/trpg_master/campaign/server.ex
+++ b/lib/trpg_master/campaign/server.ex
@@ -51,6 +51,10 @@ defmodule TrpgMaster.Campaign.Server do
     history = state.conversation_history ++ [%{"role" => "user", "content" => message}]
     state = %{state | conversation_history: history, turn_count: state.turn_count + 1}
 
+    Logger.info(
+      "플레이어 액션 처리 시작 [#{state.id}] 턴 #{state.turn_count} — 히스토리: #{length(history)}개"
+    )
+
     # 2. Build system prompt with campaign context
     system_prompt = PromptBuilder.build(state)
 
@@ -58,12 +62,25 @@ defmodule TrpgMaster.Campaign.Server do
     tools = Tools.definitions() ++ Tools.state_tool_definitions()
 
     # 4. Call AI (trim history for token budget)
-    trimmed_history = PromptBuilder.trim_history(history)
+    trimmed_history = PromptBuilder.build_messages(history)
 
     case Client.chat(system_prompt, trimmed_history, tools) do
       {:ok, result} ->
         # 5. Process state-change tool results
+        state_before = state
         state = apply_tool_results(state, result.tool_results)
+
+        if map_size(state.npcs) != map_size(state_before.npcs) do
+          Logger.info(
+            "NPC 상태 변경 [#{state.id}]: #{map_size(state_before.npcs)}개 → #{map_size(state.npcs)}개 (#{Map.keys(state.npcs) |> Enum.join(", ")})"
+          )
+        end
+
+        if length(state.characters) != length(state_before.characters) do
+          Logger.info(
+            "캐릭터 상태 변경 [#{state.id}]: #{length(state_before.characters)}개 → #{length(state.characters)}개"
+          )
+        end
 
         # 6. Add assistant response to conversation history
         state = %{
@@ -72,12 +89,17 @@ defmodule TrpgMaster.Campaign.Server do
               state.conversation_history ++ [%{"role" => "assistant", "content" => result.text}]
         }
 
-        # 7. Save async
+        # 7. Save async with updated state
         Persistence.save_async(state)
+
+        Logger.info(
+          "턴 #{state.turn_count} 저장 완료 [#{state.id}] — npcs: #{map_size(state.npcs)}개, characters: #{length(state.characters)}개, history: #{length(state.conversation_history)}개"
+        )
 
         {:reply, {:ok, result}, state}
 
       {:error, reason} ->
+        Logger.error("AI 호출 실패 [#{state.id}]: #{inspect(reason)}")
         {:reply, {:error, reason}, state}
     end
   end
@@ -98,10 +120,13 @@ defmodule TrpgMaster.Campaign.Server do
     char_name = input["character_name"]
     changes = input["changes"] || %{}
 
+    Logger.info("캐릭터 업데이트: #{char_name} — #{inspect(changes)}")
+
     characters =
       case Enum.find_index(state.characters, &(&1["name"] == char_name)) do
         nil ->
           # Character doesn't exist, create it
+          Logger.info("새 캐릭터 생성: #{char_name}")
           [Map.merge(%{"name" => char_name}, changes) | state.characters]
 
         idx ->
@@ -116,6 +141,8 @@ defmodule TrpgMaster.Campaign.Server do
 
   defp apply_single_tool_result(state, %{tool: "register_npc", input: input}) do
     name = input["name"]
+
+    Logger.info("NPC 등록: #{name} — #{inspect(input |> Map.drop(["name"]))}")
 
     npc_data =
       Map.merge(
@@ -156,12 +183,16 @@ defmodule TrpgMaster.Campaign.Server do
   end
 
   defp apply_single_tool_result(state, %{tool: "set_location", input: input}) do
+    Logger.info("위치 변경: #{state.current_location} → #{input["location_name"]}")
     %{state | current_location: input["location_name"]}
   end
 
   defp apply_single_tool_result(state, %{tool: "start_combat", input: input}) do
+    participants = input["participants"] || []
+    Logger.info("전투 시작: #{Enum.join(participants, ", ")}")
+
     combat = %{
-      "participants" => input["participants"] || [],
+      "participants" => participants,
       "round" => 1,
       "turn_order" => []
     }
@@ -170,10 +201,14 @@ defmodule TrpgMaster.Campaign.Server do
   end
 
   defp apply_single_tool_result(state, %{tool: "end_combat", input: _input}) do
+    Logger.info("전투 종료")
     %{state | phase: :exploration, combat_state: nil}
   end
 
-  defp apply_single_tool_result(state, _result), do: state
+  defp apply_single_tool_result(state, result) do
+    Logger.debug("알 수 없는 도구 결과 무시: #{inspect(result.tool)}")
+    state
+  end
 
   defp apply_character_changes(char, changes) do
     char

--- a/lib/trpg_master/campaign/state.ex
+++ b/lib/trpg_master/campaign/state.ex
@@ -19,6 +19,7 @@ defmodule TrpgMaster.Campaign.State do
 
   @doc """
   State 구조체를 직렬화 가능한 맵으로 변환한다.
+  character_names, npc_names 포함: 히스토리 트리밍 후에도 AI가 시스템 프롬프트에서 파악 가능.
   """
   def to_summary(%__MODULE__{} = state) do
     %{
@@ -30,7 +31,9 @@ defmodule TrpgMaster.Campaign.State do
       "turn_count" => state.turn_count,
       "mode" => to_string(state.mode),
       "combat_state" => state.combat_state,
-      "updated_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      "updated_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "character_names" => state.characters |> Enum.map(& &1["name"]) |> Enum.reject(&is_nil/1),
+      "npc_names" => Map.keys(state.npcs)
     }
   end
 

--- a/lib/trpg_master_web/components/game_components.ex
+++ b/lib/trpg_master_web/components/game_components.ex
@@ -63,6 +63,42 @@ defmodule TrpgMasterWeb.GameComponents do
   end
 
   @doc """
+  캐릭터 상태바 컴포넌트.
+  채팅 화면 하단에 HP, AC, 주문 슬롯, 현재 위치를 표시.
+  """
+  attr :character, :map, default: nil
+  attr :location, :string, default: nil
+  attr :phase, :atom, default: :exploration
+  attr :combat_state, :map, default: nil
+
+  def status_bar(assigns) do
+    ~H"""
+    <div class="status-bar">
+      <%= if @character do %>
+        <span class="status-item">
+          ❤️ <strong><%= @character["hp_current"] || "?" %>/<%= @character["hp_max"] || "?" %></strong>
+        </span>
+        <%= if @character["ac"] do %>
+          <span class="status-item">🛡️ AC <strong><%= @character["ac"] %></strong></span>
+        <% end %>
+        <%= if spell_slot_total(@character) > 0 do %>
+          <span class="status-item">⚡ <strong><%= spell_slots_display(@character) %></strong></span>
+        <% end %>
+      <% end %>
+      <span class="status-item">📍 <%= @location || "미정" %></span>
+      <%= if @phase == :combat && @combat_state do %>
+        <span class="status-item combat-badge">
+          ⚔️ <strong><%= @combat_state["round"] || 1 %>라운드</strong>
+          <%= if @combat_state["participants"] do %>
+            — <%= Enum.join(@combat_state["participants"], " → ") %>
+          <% end %>
+        </span>
+      <% end %>
+    </div>
+    """
+  end
+
+  @doc """
   타이핑 인디케이터.
   """
   def typing_indicator(assigns) do
@@ -87,4 +123,35 @@ defmodule TrpgMasterWeb.GameComponents do
   end
 
   defp format_text(_), do: ""
+
+  # 주문 슬롯 표시 (예: "1/3")
+  defp spell_slots_display(character) do
+    slots = character["spell_slots"] || %{}
+    used = character["spell_slots_used"] || %{}
+    total = spell_slot_total(character)
+
+    used_count =
+      used
+      |> Enum.map(fn {_k, v} -> if is_integer(v), do: v, else: 0 end)
+      |> Enum.sum()
+
+    total_count =
+      slots
+      |> Enum.map(fn {_k, v} -> if is_integer(v), do: v, else: 0 end)
+      |> Enum.sum()
+
+    if total > 0 do
+      "주문 슬롯 #{total_count - used_count}/#{total_count}"
+    else
+      ""
+    end
+  end
+
+  defp spell_slot_total(character) do
+    slots = character["spell_slots"] || %{}
+
+    slots
+    |> Enum.map(fn {_k, v} -> if is_integer(v), do: v, else: 0 end)
+    |> Enum.sum()
+  end
 end

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -24,7 +24,9 @@ defmodule TrpgMasterWeb.CampaignLive do
          |> assign(:loading, false)
          |> assign(:error, nil)
          |> assign(:current_location, state.current_location)
-         |> assign(:phase, state.phase)}
+         |> assign(:phase, state.phase)
+         |> assign(:character, List.first(state.characters))
+         |> assign(:combat_state, state.combat_state)}
 
       {:error, :not_found} ->
         {:ok,
@@ -91,7 +93,9 @@ defmodule TrpgMasterWeb.CampaignLive do
          |> assign(:messages, messages)
          |> assign(:loading, false)
          |> assign(:current_location, state.current_location)
-         |> assign(:phase, state.phase)}
+         |> assign(:phase, state.phase)
+         |> assign(:character, List.first(state.characters))
+         |> assign(:combat_state, state.combat_state)}
 
       {:error, reason} ->
         {:noreply,
@@ -146,6 +150,13 @@ defmodule TrpgMasterWeb.CampaignLive do
           </div>
         <% end %>
       </div>
+
+      <.status_bar
+        character={@character}
+        location={@current_location}
+        phase={@phase}
+        combat_state={@combat_state}
+      />
 
       <form class="input-area" phx-submit="send_message">
         <input

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -239,6 +239,44 @@ html, body {
   flex: 1;
 }
 
+/* Status Bar */
+.status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 1rem;
+  background: var(--header-bg);
+  border-top: 1px solid var(--border-color);
+  flex-shrink: 0;
+  overflow-x: auto;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  scrollbar-width: none;
+}
+
+.status-bar::-webkit-scrollbar {
+  display: none;
+}
+
+.status-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.status-item strong {
+  color: var(--text-primary);
+}
+
+.combat-badge {
+  color: #e06c75;
+}
+
+.combat-badge strong {
+  color: #e06c75;
+}
+
 /* Input Area */
 .input-area {
   display: flex;


### PR DESCRIPTION
## 버그 수정

### 버그 1&2: 매 턴 저장 + NPC 기억
- server.ex: apply_tool_results 후 save_async 호출 플로우 명시적 확인
- 각 상태 변경 도구(register_npc, update_character, set_location, start/end_combat)에
  Logger.info 로그 추가 — 도구 호출 여부와 state 반영 여부를 즉시 확인 가능
- 저장 완료 후 "턴 N 저장 완료, npcs: N개, characters: N개" 로그 출력

### 버그 2: NPC 기억 강화 (시스템 프롬프트)
- state_tools_instruction을 대폭 강화: "예외 없음" 규칙 명시
- "register_npc를 호출하지 않으면 서버가 이 NPC를 전혀 기억하지 못합니다" 경고 추가
- 도구 미사용 시 결과(다음 턴에 정보 소실)를 명시적으로 설명

## Phase 4: 컨텍스트 윈도우 최적화

### 토큰 기반 히스토리 트리밍 (핵심)
- PromptBuilder.build_messages/1 구현: 메시지 수 제한 → 토큰 예산 기반으로 교체
- @max_history_tokens 40_000 예산: 최근 메시지부터 역순 누적, 예산 초과 시 오래된 것 제거
- 한국어 위주 혼합 텍스트: 1토큰/2문자 보수적 추정
- trim_history/1은 build_messages/1의 alias로 하위 호환 유지
- 트리밍 발생 시 로그 출력

### AI.Client model 옵션 추가
- chat/4: opts 키워드 리스트 추가, model: "..." 으로 Haiku 등 다른 모델 지정 가능
- 향후 요약 자동 생성(Haiku)을 위한 기반 마련

### campaign-summary.json 개선
- State.to_summary에 character_names, npc_names 필드 추가
- 히스토리 트리밍 후에도 AI가 시스템 프롬프트에서 캐릭터/NPC 목록 파악 가능

## Phase 4: 상태바 UI

### GameComponents.status_bar/1 컴포넌트
- ❤️ HP current/max, 🛡️ AC, ⚡ 주문 슬롯, 📍 위치 표시
- 전투 중이면 ⚔️ 라운드 + 참가자 표시 (combat-badge 스타일)
- 모바일: overflow-x: auto + scrollbar 숨김으로 가로 스크롤

### CampaignLive 통합
- mount/handle_info에 :character, :combat_state assign 추가
- 매 턴 응답 후 상태바 자동 갱신
- 입력창 위에 상태바 렌더링

https://claude.ai/code/session_01B67ZyaHExHVvqdDHauTwLp