### PR TITLE
Phase 5: 폴리싱 + 안정화

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -3,7 +3,8 @@ import Config
 config :trpg_master,
   anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
   data_dir: System.get_env("DATA_DIR", "data"),
-  ai_model: System.get_env("AI_MODEL", "claude-sonnet-4-20250514")
+  ai_model: System.get_env("AI_MODEL", "claude-sonnet-4-20250514"),
+  auth_password: System.get_env("AUTH_PASSWORD")
 
 if config_env() == :prod do
   secret_key_base =

--- a/lib/trpg_master/ai/client.ex
+++ b/lib/trpg_master/ai/client.ex
@@ -2,6 +2,7 @@ defmodule TrpgMaster.AI.Client do
   @moduledoc """
   Claude API 호출 + tool use 루프.
   Erlang :httpc를 사용하여 외부 HTTP 의존성 없이 구현.
+  에러 발생 시 자동 재시도 (토큰 한도, rate limit, 서버 에러).
   """
 
   require Logger
@@ -26,7 +27,7 @@ defmodule TrpgMaster.AI.Client do
     api_key = Application.get_env(:trpg_master, :anthropic_api_key)
 
     if is_nil(api_key) || api_key == "" do
-      {:error, "ANTHROPIC_API_KEY가 설정되지 않았습니다"}
+      {:error, :no_api_key}
     else
       selected_model = Keyword.get(opts, :model, model())
       max_tokens = Keyword.get(opts, :max_tokens, 4096)
@@ -39,16 +40,80 @@ defmodule TrpgMaster.AI.Client do
         tools: tools
       }
 
-      do_chat_loop(api_key, body, [], @max_tool_iterations, %{
-        input_tokens: 0,
-        output_tokens: 0
-      })
+      do_chat_with_retry(api_key, body, 0)
     end
   end
 
+  # ── 재시도 래퍼 ─────────────────────────────────────────────────────────────
+
+  defp do_chat_with_retry(api_key, body, retry_count) do
+    case do_chat_loop(api_key, body, [], @max_tool_iterations, %{
+           input_tokens: 0,
+           output_tokens: 0
+         }) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, reason} ->
+        handle_api_error(api_key, body, reason, retry_count)
+    end
+  end
+
+  defp handle_api_error(api_key, body, {:api_error, 400, _error_body}, retry_count)
+       when retry_count < 2 do
+    # 토큰 한도 초과 — 히스토리를 공격적으로 트리밍 후 재시도
+    Logger.warning("API 400 오류 — 히스토리 트리밍 후 재시도 (#{retry_count + 1}/2)")
+    trimmed_body = aggressive_trim_history(body)
+    do_chat_with_retry(api_key, trimmed_body, retry_count + 1)
+  end
+
+  defp handle_api_error(api_key, body, {:api_error, 429, _error_body}, retry_count)
+       when retry_count < 3 do
+    # Rate limit — 지수 백오프 후 재시도
+    wait_ms = 2000 * (retry_count + 1)
+    Logger.warning("Rate limit — #{wait_ms}ms 대기 후 재시도 (#{retry_count + 1}/3)")
+    Process.sleep(wait_ms)
+    do_chat_with_retry(api_key, body, retry_count + 1)
+  end
+
+  defp handle_api_error(api_key, body, {:api_error, status, _error_body}, retry_count)
+       when status in [500, 529] and retry_count < 2 do
+    # 서버 에러 — 잠시 대기 후 재시도
+    Logger.warning("서버 에러 #{status} — 3초 대기 후 재시도 (#{retry_count + 1}/2)")
+    Process.sleep(3000)
+    do_chat_with_retry(api_key, body, retry_count + 1)
+  end
+
+  defp handle_api_error(_api_key, _body, {:api_error, 401, _}, _retry_count) do
+    {:error, :invalid_api_key}
+  end
+
+  defp handle_api_error(_api_key, _body, reason, _retry_count) do
+    {:error, reason}
+  end
+
+  # 히스토리를 절반으로 줄이는 공격적 트리밍
+  defp aggressive_trim_history(body) do
+    messages = body.messages
+    half = max(div(length(messages), 2), 2)
+    # 최신 메시지의 절반만 유지, user 메시지로 시작해야 함
+    trimmed = Enum.take(messages, -half)
+
+    trimmed =
+      case trimmed do
+        [%{role: "assistant"} | rest] -> rest
+        other -> other
+      end
+
+    Logger.info("공격적 트리밍: #{length(messages)}개 → #{length(trimmed)}개")
+    %{body | messages: trimmed}
+  end
+
+  # ── Chat loop ───────────────────────────────────────────────────────────────
+
   defp do_chat_loop(_api_key, _body, _tool_results, 0, _usage) do
     Logger.warning("Tool use 최대 반복 횟수 초과")
-    {:error, "도구 사용 반복 횟수 초과 (#{@max_tool_iterations}회)"}
+    {:error, :max_tool_iterations}
   end
 
   defp do_chat_loop(api_key, body, tool_results, iterations_left, usage) do
@@ -74,7 +139,6 @@ defmodule TrpgMaster.AI.Client do
     content = Map.get(response, "content", [])
     stop_reason = Map.get(response, "stop_reason")
 
-    # Extract text blocks and tool_use blocks
     text_parts =
       content
       |> Enum.filter(&(&1["type"] == "text"))
@@ -85,10 +149,8 @@ defmodule TrpgMaster.AI.Client do
       |> Enum.filter(&(&1["type"] == "tool_use"))
 
     if stop_reason == "tool_use" && length(tool_use_blocks) > 0 do
-      # Execute tools and continue the loop
       {new_tool_results, tool_result_blocks} = execute_tools(tool_use_blocks)
 
-      # Add assistant message (with tool_use) and user message (with tool_results)
       updated_messages =
         body.messages ++
           [
@@ -106,7 +168,6 @@ defmodule TrpgMaster.AI.Client do
         usage
       )
     else
-      # Final response — no more tool use
       final_text = Enum.join(text_parts, "\n")
 
       {:ok,
@@ -150,8 +211,9 @@ defmodule TrpgMaster.AI.Client do
     {Enum.map(results, &elem(&1, 0)), Enum.map(results, &elem(&1, 1))}
   end
 
+  # ── HTTP ────────────────────────────────────────────────────────────────────
+
   defp call_api(api_key, body) do
-    # Ensure :ssl and :inets are started
     :ssl.start()
     :inets.start()
 
@@ -163,7 +225,6 @@ defmodule TrpgMaster.AI.Client do
       {~c"content-type", ~c"application/json"}
     ]
 
-    # Configure SSL with system CA certs
     ssl_opts = ssl_options()
 
     http_opts = [
@@ -178,17 +239,30 @@ defmodule TrpgMaster.AI.Client do
       {:ok, {{_, status, _}, _headers, resp_body}} when status in 200..299 ->
         case Jason.decode(:erlang.list_to_binary(resp_body)) do
           {:ok, parsed} -> {:ok, parsed}
-          {:error, reason} -> {:error, "JSON 파싱 오류: #{inspect(reason)}"}
+          {:error, reason} -> {:error, {:json_parse_error, reason}}
         end
 
       {:ok, {{_, status, _}, _headers, resp_body}} ->
         body_str = :erlang.list_to_binary(resp_body)
         Logger.error("Claude API 오류 #{status}: #{body_str}")
-        {:error, "API 오류 (#{status}): #{String.slice(body_str, 0, 200)}"}
+
+        error_body =
+          case Jason.decode(body_str) do
+            {:ok, parsed} -> parsed
+            _ -> %{"raw" => String.slice(body_str, 0, 300)}
+          end
+
+        {:error, {:api_error, status, error_body}}
+
+      {:error, {:failed_connect, _}} ->
+        {:error, :connection_failed}
+
+      {:error, :timeout} ->
+        {:error, :timeout}
 
       {:error, reason} ->
         Logger.error("HTTP 요청 실패: #{inspect(reason)}")
-        {:error, "HTTP 요청 실패: #{inspect(reason)}"}
+        {:error, {:http_error, reason}}
     end
   end
 
@@ -212,4 +286,33 @@ defmodule TrpgMaster.AI.Client do
   defp model do
     Application.get_env(:trpg_master, :ai_model, "claude-sonnet-4-20250514")
   end
+
+  @doc """
+  API 에러 atom/tuple을 사용자 친화적인 한국어 메시지로 변환한다.
+  """
+  def format_error(:no_api_key), do: "ANTHROPIC_API_KEY가 설정되지 않았습니다."
+  def format_error(:invalid_api_key), do: "API 키가 올바르지 않습니다. 설정을 확인해주세요."
+  def format_error(:timeout), do: "AI 응답이 너무 오래 걸리고 있습니다. 다시 시도해주세요."
+  def format_error(:connection_failed), do: "네트워크 연결에 실패했습니다. 인터넷 연결을 확인해주세요."
+  def format_error(:max_tool_iterations), do: "도구 실행이 너무 많아 중단되었습니다. 다시 시도해주세요."
+
+  def format_error({:api_error, 400, body}) do
+    msg = get_in(body, ["error", "message"]) || ""
+
+    if String.contains?(msg, "token") do
+      "대화가 너무 길어져서 이전 대화를 정리했습니다. 계속 진행해주세요."
+    else
+      "요청 오류가 발생했습니다. 다시 시도해주세요."
+    end
+  end
+
+  def format_error({:api_error, 429, _}), do: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+
+  def format_error({:api_error, status, _}) when status in [500, 529],
+    do: "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+
+  def format_error({:api_error, status, _}), do: "API 오류 (#{status}). 다시 시도해주세요."
+
+  def format_error(reason) when is_binary(reason), do: reason
+  def format_error(reason), do: "오류가 발생했습니다: #{inspect(reason)}"
 end

--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -15,13 +15,15 @@ defmodule TrpgMaster.AI.PromptBuilder do
 
   @doc """
   Campaign.State를 받아서 풍부한 시스템 프롬프트를 조립한다.
+  mode에 따라 디버그/모험 분기를 추가한다.
   """
   def build(%State{} = state) do
     base = system_prompt()
     context = build_campaign_context(state)
     tools_instruction = state_tools_instruction()
+    mode_instruction = mode_instruction(state.mode)
 
-    "#{base}\n\n#{context}\n\n#{tools_instruction}"
+    "#{base}\n\n#{context}\n\n#{tools_instruction}\n\n#{mode_instruction}"
   end
 
   @doc """
@@ -218,6 +220,31 @@ defmodule TrpgMaster.AI.PromptBuilder do
     일관성 있는 게임 진행을 위해 모든 상태 변경을 반드시 도구로 기록하세요.
     """
   end
+
+  defp mode_instruction(:adventure) do
+    """
+    ## 🎭 모험 모드 (현재 활성)
+
+    - 몬스터 스탯(AC, HP, 공격 보너스 등)을 플레이어에게 직접 공개하지 않습니다.
+    - 숨겨진 판정(숨겨진 DC, 몬스터의 주사위 결과)은 서술로만 처리하고 수치를 노출하지 않습니다.
+    - DM 전용 정보(罠의 DC, 적의 전투 계획 등)는 플레이어 서술에 포함하지 않습니다.
+    - 몰입감 있는 서술을 최우선으로 합니다.
+    """
+  end
+
+  defp mode_instruction(:debug) do
+    """
+    ## 🔧 디버그 모드 (현재 활성)
+
+    - 모든 판정의 DC, 주사위 결과, 수정치를 명시적으로 공개합니다.
+    - 몬스터 스탯(AC, HP, 공격 보너스 등)을 공개합니다.
+    - 룰 판정 근거를 설명합니다 (예: "민첩 내성 DC 14, 결과 17 → 성공").
+    - 도구 호출 결과를 자세히 설명합니다.
+    - 학습/테스트 목적에 최적화된 모드입니다.
+    """
+  end
+
+  defp mode_instruction(_), do: mode_instruction(:adventure)
 
   defp default_system_prompt do
     """

--- a/lib/trpg_master/campaign/persistence.ex
+++ b/lib/trpg_master/campaign/persistence.ex
@@ -104,6 +104,40 @@ defmodule TrpgMaster.Campaign.Persistence do
   end
 
   @doc """
+  세션 로그를 campaign-log.md에 추가한다.
+  """
+  def append_session_log(%State{} = state, session_number, summary_text) do
+    dir = campaign_dir(state.id)
+    log_path = Path.join(dir, "campaign-log.md")
+
+    date_str = Date.utc_today() |> Date.to_iso8601()
+
+    # 파티 현황 섹션
+    party_section = format_party_section(state)
+
+    entry = """
+
+    ---
+
+    # 세션 #{session_number} — #{date_str}
+
+    #{summary_text}
+
+    #{party_section}
+    """
+
+    case File.write(log_path, entry, [:append]) do
+      :ok ->
+        Logger.info("세션 로그 추가 완료 [#{state.id}] 세션 #{session_number}")
+        :ok
+
+      {:error, reason} ->
+        Logger.error("세션 로그 저장 실패 [#{state.id}]: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
   캠페인 데이터를 삭제한다.
   """
   def delete(campaign_id) do
@@ -221,6 +255,32 @@ defmodule TrpgMaster.Campaign.Persistence do
     else
       {:ok, %{}}
     end
+  end
+
+  defp format_party_section(state) do
+    chars =
+      state.characters
+      |> Enum.map(fn c ->
+        hp = if c["hp_current"] && c["hp_max"], do: " HP #{c["hp_current"]}/#{c["hp_max"]}", else: ""
+        "- #{c["name"]}#{hp}"
+      end)
+      |> Enum.join("\n")
+
+    quests =
+      state.active_quests
+      |> Enum.map(fn q -> "- #{q["name"]} [#{q["status"] || "진행중"}]" end)
+      |> Enum.join("\n")
+
+    location = state.current_location || "미정"
+
+    """
+    ## 파티 현황 (자동 기록)
+    - 위치: #{location}
+    #{if chars != "", do: chars, else: "- (캐릭터 없음)"}
+
+    ## 활성 퀘스트
+    #{if quests != "", do: quests, else: "- (없음)"}
+    """
   end
 
   defp load_conversation_history(dir) do

--- a/lib/trpg_master/campaign/server.ex
+++ b/lib/trpg_master/campaign/server.ex
@@ -2,6 +2,7 @@ defmodule TrpgMaster.Campaign.Server do
   @moduledoc """
   캠페인 하나 = GenServer 프로세스 하나.
   플레이어 메시지 처리, 상태 관리, AI 호출을 담당한다.
+  크래시 후 재시작 시 Persistence.load로 자동 복원한다.
   """
 
   use GenServer
@@ -25,6 +26,14 @@ defmodule TrpgMaster.Campaign.Server do
     GenServer.call(via(campaign_id), :get_state)
   end
 
+  def set_mode(campaign_id, mode) when mode in [:adventure, :debug] do
+    GenServer.call(via(campaign_id), {:set_mode, mode})
+  end
+
+  def end_session(campaign_id) do
+    GenServer.call(via(campaign_id), :end_session, 120_000)
+  end
+
   def alive?(campaign_id) do
     case Registry.lookup(TrpgMaster.Campaign.Registry, campaign_id) do
       [{_pid, _}] -> true
@@ -35,9 +44,17 @@ defmodule TrpgMaster.Campaign.Server do
   # ── GenServer Callbacks ─────────────────────────────────────────────────────
 
   @impl true
-  def init(%State{} = state) do
-    Logger.info("캠페인 서버 시작: #{state.name} [#{state.id}]")
-    {:ok, state}
+  def init(%State{id: campaign_id} = initial_state) do
+    # 크래시 후 재시작 시 Persistence.load로 최신 상태 복원
+    case Persistence.load(campaign_id) do
+      {:ok, loaded_state} ->
+        Logger.info("캠페인 복원: #{loaded_state.name} [#{loaded_state.id}]")
+        {:ok, loaded_state}
+
+      {:error, _} ->
+        Logger.info("캠페인 서버 시작: #{initial_state.name} [#{initial_state.id}]")
+        {:ok, initial_state}
+    end
   end
 
   @impl true
@@ -46,8 +63,37 @@ defmodule TrpgMaster.Campaign.Server do
   end
 
   @impl true
+  def handle_call({:set_mode, mode}, _from, state) do
+    new_state = %{state | mode: mode}
+    Persistence.save_async(new_state)
+    Logger.info("모드 변경 [#{state.id}]: #{state.mode} → #{mode}")
+    {:reply, :ok, new_state}
+  end
+
+  @impl true
+  def handle_call(:end_session, _from, state) do
+    Logger.info("세션 종료 처리 시작 [#{state.id}] 턴 #{state.turn_count}")
+
+    case generate_session_summary(state) do
+      {:ok, summary_text} ->
+        # 세션 로그 저장
+        session_number = div(state.turn_count, 1) |> then(fn _ -> estimate_session_number(state) end)
+        Persistence.append_session_log(state, session_number, summary_text)
+
+        # 대화 히스토리 리셋 (캐릭터/NPC/퀘스트는 유지)
+        new_state = %{state | conversation_history: []}
+        Persistence.save_async(new_state)
+
+        {:reply, {:ok, summary_text}, new_state}
+
+      {:error, reason} ->
+        Logger.error("세션 요약 생성 실패 [#{state.id}]: #{inspect(reason)}")
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  @impl true
   def handle_call({:player_action, message}, _from, state) do
-    # 1. Add player message to conversation history
     history = state.conversation_history ++ [%{"role" => "user", "content" => message}]
     state = %{state | conversation_history: history, turn_count: state.turn_count + 1}
 
@@ -55,45 +101,31 @@ defmodule TrpgMaster.Campaign.Server do
       "플레이어 액션 처리 시작 [#{state.id}] 턴 #{state.turn_count} — 히스토리: #{length(history)}개"
     )
 
-    # 2. Build system prompt with campaign context
     system_prompt = PromptBuilder.build(state)
-
-    # 3. Build tools list (existing + state-change tools)
     tools = Tools.definitions() ++ Tools.state_tool_definitions()
-
-    # 4. Call AI (trim history for token budget)
     trimmed_history = PromptBuilder.build_messages(history)
 
     case Client.chat(system_prompt, trimmed_history, tools) do
       {:ok, result} ->
-        # 5. Process state-change tool results
         state_before = state
         state = apply_tool_results(state, result.tool_results)
 
         if map_size(state.npcs) != map_size(state_before.npcs) do
           Logger.info(
-            "NPC 상태 변경 [#{state.id}]: #{map_size(state_before.npcs)}개 → #{map_size(state.npcs)}개 (#{Map.keys(state.npcs) |> Enum.join(", ")})"
+            "NPC 상태 변경 [#{state.id}]: #{map_size(state_before.npcs)}개 → #{map_size(state.npcs)}개"
           )
         end
 
-        if length(state.characters) != length(state_before.characters) do
-          Logger.info(
-            "캐릭터 상태 변경 [#{state.id}]: #{length(state_before.characters)}개 → #{length(state.characters)}개"
-          )
-        end
-
-        # 6. Add assistant response to conversation history
         state = %{
           state
           | conversation_history:
               state.conversation_history ++ [%{"role" => "assistant", "content" => result.text}]
         }
 
-        # 7. Save async with updated state
         Persistence.save_async(state)
 
         Logger.info(
-          "턴 #{state.turn_count} 저장 완료 [#{state.id}] — npcs: #{map_size(state.npcs)}개, characters: #{length(state.characters)}개, history: #{length(state.conversation_history)}개"
+          "턴 #{state.turn_count} 저장 완료 [#{state.id}] — npcs: #{map_size(state.npcs)}개, history: #{length(state.conversation_history)}개"
         )
 
         {:reply, {:ok, result}, state}
@@ -108,6 +140,88 @@ defmodule TrpgMaster.Campaign.Server do
 
   defp via(campaign_id) do
     {:via, Registry, {TrpgMaster.Campaign.Registry, campaign_id}}
+  end
+
+  defp estimate_session_number(state) do
+    # 기존 로그 파일에서 세션 번호를 추정 (간단하게 turn_count 기반)
+    max(1, div(state.turn_count, 5))
+  end
+
+  defp generate_session_summary(state) do
+    # 비용 절약을 위해 Haiku 모델 사용
+    haiku_model = "claude-haiku-4-5-20251001"
+
+    summary_prompt = """
+    당신은 D&D 세션 서기입니다. 아래 세션 정보를 바탕으로 간결한 세션 요약을 작성해주세요.
+
+    ## 캠페인: #{state.name}
+    ## 위치: #{state.current_location || "미정"}
+    ## 진행 턴: #{state.turn_count}
+
+    ## 캐릭터
+    #{format_characters(state.characters)}
+
+    ## NPC
+    #{format_npcs(state.npcs)}
+
+    ## 퀘스트
+    #{format_quests(state.active_quests)}
+
+    위 정보를 바탕으로 다음 형식으로 요약을 작성해주세요:
+
+    ## 세션 요약
+    (이번 세션의 주요 사건을 2~3문단으로 요약)
+
+    ## 파티 현황
+    (캐릭터 HP, 현재 위치, 활성 퀘스트)
+
+    ## 등장 NPC
+    (이번 세션에 등장한 NPC 목록)
+
+    ## 다음 세션 예고
+    (다음 세션에서 할 일이나 남은 미스터리를 1~2문장으로)
+    """
+
+    # 최근 대화 히스토리만 포함 (마지막 20개)
+    recent_history = Enum.take(state.conversation_history, -20)
+
+    case Client.chat(summary_prompt, recent_history, [], model: haiku_model, max_tokens: 1024) do
+      {:ok, result} -> {:ok, result.text}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp format_characters([]), do: "(없음)"
+
+  defp format_characters(characters) do
+    characters
+    |> Enum.map(fn c ->
+      hp = if c["hp_current"] && c["hp_max"], do: " HP #{c["hp_current"]}/#{c["hp_max"]}", else: ""
+      "- #{c["name"]}#{hp}"
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp format_npcs(npcs) when map_size(npcs) == 0, do: "(없음)"
+
+  defp format_npcs(npcs) do
+    npcs
+    |> Enum.map(fn {name, data} ->
+      desc = if data["description"], do: " — #{data["description"]}", else: ""
+      "- #{name}#{desc}"
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp format_quests([]), do: "(없음)"
+
+  defp format_quests(quests) do
+    quests
+    |> Enum.map(fn q ->
+      status = if q["status"], do: " [#{q["status"]}]", else: ""
+      "- #{q["name"]}#{status}"
+    end)
+    |> Enum.join("\n")
   end
 
   defp apply_tool_results(state, tool_results) do
@@ -125,14 +239,12 @@ defmodule TrpgMaster.Campaign.Server do
     characters =
       case Enum.find_index(state.characters, &(&1["name"] == char_name)) do
         nil ->
-          # Character doesn't exist, create it
           Logger.info("새 캐릭터 생성: #{char_name}")
           [Map.merge(%{"name" => char_name}, changes) | state.characters]
 
         idx ->
           List.update_at(state.characters, idx, fn char ->
-            char
-            |> apply_character_changes(changes)
+            apply_character_changes(char, changes)
           end)
       end
 
@@ -141,8 +253,7 @@ defmodule TrpgMaster.Campaign.Server do
 
   defp apply_single_tool_result(state, %{tool: "register_npc", input: input}) do
     name = input["name"]
-
-    Logger.info("NPC 등록: #{name} — #{inspect(input |> Map.drop(["name"]))}")
+    Logger.info("NPC 등록: #{name}")
 
     npc_data =
       Map.merge(
@@ -229,13 +340,8 @@ defmodule TrpgMaster.Campaign.Server do
 
   defp apply_list_change(map, key, add, remove) do
     current = Map.get(map, key, [])
-
-    current =
-      if is_list(add), do: current ++ add, else: current
-
-    current =
-      if is_list(remove), do: current -- remove, else: current
-
+    current = if is_list(add), do: current ++ add, else: current
+    current = if is_list(remove), do: current -- remove, else: current
     Map.put(map, key, current)
   end
 end

--- a/lib/trpg_master_web/components/game_components.ex
+++ b/lib/trpg_master_web/components/game_components.ex
@@ -70,6 +70,7 @@ defmodule TrpgMasterWeb.GameComponents do
   attr :location, :string, default: nil
   attr :phase, :atom, default: :exploration
   attr :combat_state, :map, default: nil
+  attr :mode, :atom, default: :adventure
 
   def status_bar(assigns) do
     ~H"""
@@ -90,9 +91,12 @@ defmodule TrpgMasterWeb.GameComponents do
         <span class="status-item combat-badge">
           ⚔️ <strong><%= @combat_state["round"] || 1 %>라운드</strong>
           <%= if @combat_state["participants"] do %>
-            — <%= Enum.join(@combat_state["participants"], " → ") %>
+            — <%= Enum.join(@combat_state["participants"], " vs ") %>
           <% end %>
         </span>
+      <% end %>
+      <%= if @mode == :debug do %>
+        <span class="status-item debug-badge">🔧 디버그</span>
       <% end %>
     </div>
     """

--- a/lib/trpg_master_web/components/layouts/root.html.heex
+++ b/lib/trpg_master_web/components/layouts/root.html.heex
@@ -14,15 +14,58 @@
     <script>
       let Hooks = {};
 
+      // 채팅 영역 자동 스크롤 (사용자가 위로 스크롤 중이면 멈춤)
       Hooks.ScrollBottom = {
         mounted() {
+          this.userScrolled = false;
+          this.el.addEventListener("scroll", () => {
+            const el = this.el;
+            const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+            this.userScrolled = !atBottom;
+          });
           this.scrollToBottom();
-          this.observer = new MutationObserver(() => { this.scrollToBottom(); });
+          this.observer = new MutationObserver(() => {
+            if (!this.userScrolled) this.scrollToBottom();
+          });
           this.observer.observe(this.el, { childList: true, subtree: true });
         },
-        updated() { this.scrollToBottom(); },
-        destroyed() { if (this.observer) this.observer.disconnect(); },
-        scrollToBottom() { this.el.scrollTop = this.el.scrollHeight; }
+        updated() {
+          if (!this.userScrolled) this.scrollToBottom();
+        },
+        destroyed() {
+          if (this.observer) this.observer.disconnect();
+        },
+        scrollToBottom() {
+          this.el.scrollTop = this.el.scrollHeight;
+        }
+      };
+
+      // Textarea 자동 높이 조절 + Shift+Enter 줄바꿈 / Enter 전송
+      Hooks.AutoResize = {
+        mounted() {
+          this.resize();
+          this.el.addEventListener("input", () => this.resize());
+          this.el.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              const form = this.el.closest("form");
+              if (form) {
+                const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
+                form.dispatchEvent(submitEvent);
+              }
+            }
+          });
+        },
+        updated() {
+          // LiveView 업데이트 후 높이 리셋 (메시지 전송 후 비워질 때)
+          if (this.el.value === "") {
+            this.el.style.height = "44px";
+          }
+        },
+        resize() {
+          this.el.style.height = "auto";
+          this.el.style.height = Math.min(this.el.scrollHeight, 160) + "px";
+        }
       };
 
       let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");

--- a/lib/trpg_master_web/controllers/login_controller.ex
+++ b/lib/trpg_master_web/controllers/login_controller.ex
@@ -1,0 +1,25 @@
+defmodule TrpgMasterWeb.LoginController do
+  use TrpgMasterWeb, :controller
+
+  def show(conn, _params) do
+    render(conn, :show, error: nil)
+  end
+
+  def login(conn, %{"password" => password}) do
+    expected = Application.get_env(:trpg_master, :auth_password)
+
+    if is_nil(expected) || expected == "" || password == expected do
+      conn
+      |> put_session(:authenticated, true)
+      |> redirect(to: ~p"/")
+    else
+      render(conn, :show, error: "비밀번호가 틀렸습니다.")
+    end
+  end
+
+  def logout(conn, _params) do
+    conn
+    |> delete_session(:authenticated)
+    |> redirect(to: ~p"/login")
+  end
+end

--- a/lib/trpg_master_web/controllers/login_html.ex
+++ b/lib/trpg_master_web/controllers/login_html.ex
@@ -1,0 +1,5 @@
+defmodule TrpgMasterWeb.LoginHTML do
+  use TrpgMasterWeb, :html
+
+  embed_templates "login_html/*"
+end

--- a/lib/trpg_master_web/controllers/login_html/show.html.heex
+++ b/lib/trpg_master_web/controllers/login_html/show.html.heex
@@ -1,0 +1,23 @@
+<div class="login-container">
+  <div class="login-box">
+    <h1 class="login-title">⚔️ AI TRPG Master</h1>
+    <p class="login-subtitle">모험을 시작하려면 비밀번호를 입력하세요</p>
+
+    <%= if @error do %>
+      <div class="login-error"><%= @error %></div>
+    <% end %>
+
+    <form action={~p"/login"} method="post" class="login-form">
+      <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+      <input
+        type="password"
+        name="password"
+        placeholder="비밀번호"
+        autocomplete="current-password"
+        autofocus
+        class="login-input"
+      />
+      <button type="submit" class="login-btn">입장</button>
+    </form>
+  </div>
+</div>

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -4,15 +4,13 @@ defmodule TrpgMasterWeb.CampaignLive do
   import TrpgMasterWeb.GameComponents
 
   alias TrpgMaster.Campaign.{Manager, Server}
+  alias TrpgMaster.AI.Client
 
   @impl true
   def mount(%{"id" => campaign_id}, _session, socket) do
-    # Ensure the campaign server is running
     case Manager.start_campaign(campaign_id) do
       {:ok, _id} ->
         state = Server.get_state(campaign_id)
-
-        # Build display messages from conversation history
         messages = build_display_messages(state.conversation_history)
 
         {:ok,
@@ -23,10 +21,13 @@ defmodule TrpgMasterWeb.CampaignLive do
          |> assign(:input_text, "")
          |> assign(:loading, false)
          |> assign(:error, nil)
+         |> assign(:last_player_message, nil)
          |> assign(:current_location, state.current_location)
          |> assign(:phase, state.phase)
          |> assign(:character, List.first(state.characters))
-         |> assign(:combat_state, state.combat_state)}
+         |> assign(:combat_state, state.combat_state)
+         |> assign(:mode, state.mode)
+         |> assign(:ending_session, false)}
 
       {:error, :not_found} ->
         {:ok,
@@ -36,6 +37,8 @@ defmodule TrpgMasterWeb.CampaignLive do
     end
   end
 
+  # ── 메시지 전송 ─────────────────────────────────────────────────────────────
+
   @impl true
   def handle_event("send_message", %{"message" => message}, socket) when message != "" do
     message = String.trim(message)
@@ -43,7 +46,6 @@ defmodule TrpgMasterWeb.CampaignLive do
     if message == "" do
       {:noreply, socket}
     else
-      # Add player message to display immediately
       messages = socket.assigns.messages ++ [%{type: :player, text: message}]
 
       socket =
@@ -52,10 +54,9 @@ defmodule TrpgMasterWeb.CampaignLive do
         |> assign(:input_text, "")
         |> assign(:loading, true)
         |> assign(:error, nil)
+        |> assign(:last_player_message, message)
 
-      # Trigger async AI call via GenServer
       send(self(), {:call_ai, message})
-
       {:noreply, socket}
     end
   end
@@ -64,28 +65,76 @@ defmodule TrpgMasterWeb.CampaignLive do
     {:noreply, socket}
   end
 
+  # ── 다시 시도 ────────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("retry_last", _, socket) do
+    case socket.assigns.last_player_message do
+      nil ->
+        {:noreply, socket}
+
+      message ->
+        socket =
+          socket
+          |> assign(:loading, true)
+          |> assign(:error, nil)
+
+        send(self(), {:call_ai, message})
+        {:noreply, socket}
+    end
+  end
+
+  # ── 모드 전환 ────────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("toggle_mode", _, socket) do
+    campaign_id = socket.assigns.campaign_id
+    new_mode = if socket.assigns.mode == :adventure, do: :debug, else: :adventure
+
+    Server.set_mode(campaign_id, new_mode)
+
+    {:noreply, assign(socket, :mode, new_mode)}
+  end
+
+  # ── 세션 종료 ────────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("end_session", _, socket) do
+    socket =
+      socket
+      |> assign(:ending_session, true)
+      |> assign(:loading, true)
+
+    send(self(), :do_end_session)
+
+    {:noreply, socket}
+  end
+
+  # ── AI 호출 (info) ───────────────────────────────────────────────────────────
+
   @impl true
   def handle_info({:call_ai, message}, socket) do
     campaign_id = socket.assigns.campaign_id
 
     case Server.player_action(campaign_id, message) do
       {:ok, result} ->
-        # Add tool results to display
         messages =
           Enum.reduce(result.tool_results, socket.assigns.messages, fn tool_result, acc ->
             case tool_result do
               %{result: %{"formatted" => _} = dice_result} ->
-                acc ++ [%{type: :dice, result: dice_result}]
+                # 모험 모드에서 hidden 주사위 결과 숨김
+                if socket.assigns.mode == :adventure && Map.get(tool_result.input || %{}, "hidden") do
+                  acc
+                else
+                  acc ++ [%{type: :dice, result: dice_result}]
+                end
 
               _ ->
                 acc
             end
           end)
 
-        # Add DM response to display
         messages = messages ++ [%{type: :dm, text: result.text}]
-
-        # Get updated state for sidebar info
         state = Server.get_state(campaign_id)
 
         {:noreply,
@@ -98,12 +147,46 @@ defmodule TrpgMasterWeb.CampaignLive do
          |> assign(:combat_state, state.combat_state)}
 
       {:error, reason} ->
+        error_msg = Client.format_error(reason)
+
         {:noreply,
          socket
          |> assign(:loading, false)
-         |> assign(:error, "AI 오류: #{inspect(reason)}")}
+         |> assign(:error, error_msg)}
     end
   end
+
+  @impl true
+  def handle_info(:do_end_session, socket) do
+    campaign_id = socket.assigns.campaign_id
+
+    case Server.end_session(campaign_id) do
+      {:ok, summary_text} ->
+        messages =
+          socket.assigns.messages ++
+            [
+              %{type: :system, text: "📋 세션이 종료되었습니다. 대화 기록이 저장되었습니다."},
+              %{type: :dm, text: summary_text}
+            ]
+
+        {:noreply,
+         socket
+         |> assign(:messages, messages)
+         |> assign(:loading, false)
+         |> assign(:ending_session, false)}
+
+      {:error, reason} ->
+        error_msg = Client.format_error(reason)
+
+        {:noreply,
+         socket
+         |> assign(:loading, false)
+         |> assign(:ending_session, false)
+         |> assign(:error, "세션 종료 실패: #{error_msg}")}
+    end
+  end
+
+  # ── Render ───────────────────────────────────────────────────────────────────
 
   @impl true
   def render(assigns) do
@@ -117,6 +200,12 @@ defmodule TrpgMasterWeb.CampaignLive do
         <div class="header-right">
           <span :if={@current_location} class="location-badge"><%= @current_location %></span>
           <span class="mode-badge"><%= phase_label(@phase) %></span>
+          <button phx-click="toggle_mode" class={"mode-toggle #{if @mode == :debug, do: "mode-debug", else: "mode-adventure"}"} title={if @mode == :adventure, do: "디버그 모드로 전환", else: "모험 모드로 전환"}>
+            <%= if @mode == :adventure do %>🎭<% else %>🔧<% end %>
+          </button>
+          <button phx-click="end_session" class="end-session-btn" title="세션 종료" disabled={@loading}>
+            📋
+          </button>
         </div>
       </header>
 
@@ -140,13 +229,20 @@ defmodule TrpgMasterWeb.CampaignLive do
           <% end %>
         <% end %>
 
-        <%= if @loading do %>
+        <%= if @ending_session do %>
+          <.system_message text="📋 세션 요약을 생성 중입니다..." />
+        <% end %>
+
+        <%= if @loading && !@ending_session do %>
           <.typing_indicator />
         <% end %>
 
         <%= if @error do %>
           <div class="message error-message">
-            <span><%= @error %></span>
+            <span>⚠️ <%= @error %></span>
+            <%= if @last_player_message do %>
+              <button phx-click="retry_last" class="retry-btn">다시 시도</button>
+            <% end %>
           </div>
         <% end %>
       </div>
@@ -156,26 +252,28 @@ defmodule TrpgMasterWeb.CampaignLive do
         location={@current_location}
         phase={@phase}
         combat_state={@combat_state}
+        mode={@mode}
       />
 
-      <form class="input-area" phx-submit="send_message">
-        <input
-          type="text"
+      <form class="input-area" phx-submit="send_message" id="message-form">
+        <textarea
           name="message"
-          value={@input_text}
-          placeholder="무엇을 하시겠습니까?"
+          placeholder="무엇을 하시겠습니까? (Shift+Enter로 줄바꿈)"
           autocomplete="off"
           disabled={@loading}
-        />
-        <button type="submit" disabled={@loading}>
-          <span>전송</span>
+          rows="1"
+          phx-hook="AutoResize"
+          id="message-input"
+        ><%= @input_text %></textarea>
+        <button type="submit" disabled={@loading} aria-label="전송">
+          <span>↑</span>
         </button>
       </form>
     </div>
     """
   end
 
-  # ── Private helpers ─────────────────────────────────────────────────────────
+  # ── Private helpers ──────────────────────────────────────────────────────────
 
   defp build_display_messages(conversation_history) do
     conversation_history

--- a/lib/trpg_master_web/router.ex
+++ b/lib/trpg_master_web/router.ex
@@ -10,10 +10,43 @@ defmodule TrpgMasterWeb.Router do
     plug :put_secure_browser_headers
   end
 
+  pipeline :require_auth do
+    plug :check_session_auth
+  end
+
+  # 인증 불필요 (로그인 페이지)
   scope "/", TrpgMasterWeb do
     pipe_through :browser
 
+    get "/login", LoginController, :show
+    post "/login", LoginController, :login
+    delete "/logout", LoginController, :logout
+  end
+
+  # 인증 필요
+  scope "/", TrpgMasterWeb do
+    pipe_through [:browser, :require_auth]
+
     live "/", LobbyLive, :index
     live "/play/:id", CampaignLive, :play
+  end
+
+  # ── Auth Plug ──────────────────────────────────────────────────────────────
+
+  defp check_session_auth(conn, _opts) do
+    password = Application.get_env(:trpg_master, :auth_password)
+
+    # AUTH_PASSWORD 미설정 시 인증 건너뜀 (로컬 개발 편의)
+    if is_nil(password) || password == "" do
+      conn
+    else
+      if get_session(conn, :authenticated) do
+        conn
+      else
+        conn
+        |> Phoenix.Controller.redirect(to: "/login")
+        |> halt()
+      end
+    end
   end
 end

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -559,3 +559,215 @@ html, body {
     padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
   }
 }
+
+/* ── Phase 5: 모드 토글 + 세션 종료 버튼 ───────────────────────────── */
+
+.mode-toggle,
+.end-session-btn {
+  padding: 0.3rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  line-height: 1;
+}
+
+.mode-toggle:hover,
+.end-session-btn:hover {
+  background: var(--bg-input);
+  color: var(--text-primary);
+}
+
+.mode-toggle.mode-debug {
+  border-color: rgba(52, 152, 219, 0.5);
+  color: var(--accent-blue);
+}
+
+.end-session-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* 디버그 모드 배지 */
+.debug-badge {
+  color: var(--accent-blue);
+  font-size: 0.75rem;
+}
+
+/* ── 에러 메시지 + 다시 시도 버튼 ───────────────────────────────────── */
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.retry-btn {
+  padding: 0.3rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--accent-red);
+  background: transparent;
+  color: var(--accent-red);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.retry-btn:hover {
+  background: rgba(231, 76, 60, 0.15);
+}
+
+/* ── Textarea 입력창 ─────────────────────────────────────────────────── */
+
+.input-area textarea {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s;
+  resize: none;
+  font-family: inherit;
+  line-height: 1.5;
+  min-height: 44px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.input-area textarea:focus {
+  border-color: var(--accent-blue);
+}
+
+.input-area textarea:disabled {
+  opacity: 0.5;
+}
+
+.input-area textarea::placeholder {
+  color: var(--text-secondary);
+}
+
+.input-area button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent-gold);
+  color: var(--bg-primary);
+  font-weight: 700;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-end;
+}
+
+/* ── 로그인 페이지 ──────────────────────────────────────────────────── */
+
+.login-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem;
+}
+
+.login-box {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 360px;
+  text-align: center;
+}
+
+.login-title {
+  font-size: 1.5rem;
+  color: var(--accent-gold);
+  margin-bottom: 0.5rem;
+}
+
+.login-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.login-error {
+  background: rgba(231, 76, 60, 0.15);
+  border: 1px solid var(--accent-red);
+  color: var(--accent-red);
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 1rem;
+  outline: none;
+  text-align: center;
+}
+
+.login-input:focus {
+  border-color: var(--accent-blue);
+}
+
+.login-btn {
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: none;
+  background: var(--accent-gold);
+  color: var(--bg-primary);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.login-btn:hover {
+  opacity: 0.9;
+}
+
+/* ── 모바일 조정 ──────────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .input-area textarea {
+    font-size: 16px; /* iOS 줌 방지 */
+    padding: 0.6rem 0.8rem;
+  }
+
+  .mode-toggle,
+  .end-session-btn {
+    padding: 0.3rem 0.4rem;
+    font-size: 0.9rem;
+  }
+
+  .header-right {
+    gap: 0.25rem;
+  }
+}

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -1,3 +1,6 @@
-// This file is a placeholder.
-// The actual LiveView connection is handled via the phoenix.min.js and phoenix_live_view.min.js
-// loaded in the root layout. Hooks are defined inline.
+// AI TRPG Master — 클라이언트 JS
+// LiveView hook은 root.html.heex의 <script> 태그에서 정의된다.
+// 여기에는 추가 유틸리티만 포함한다.
+
+// 이 파일은 정적 파일로 직접 제공된다.
+// root.html.heex의 Hooks 객체에 아래 내용이 포함된다.


### PR DESCRIPTION
- AI.Client: 구조화된 에러 반환 + 자동 재시도 (400/429/500/529), format_error/1 추가
- Campaign.Server: init에서 Persistence.load로 크래시 복구, set_mode/end_session API 추가
- Campaign.Server: 세션 종료 시 Haiku로 세션 요약 생성
- Persistence: append_session_log/3 — campaign-log.md에 세션 엔트리 추가
- PromptBuilder: mode에 따라 모험/디버그 시스템 프롬프트 분기
- CampaignLive: 모드 토글 버튼, 세션 종료 버튼, 에러 안내 + 다시 시도 버튼, last_player_message 추적
- 인증: LoginController + check_session_auth plug, AUTH_PASSWORD 미설정 시 건너뜀
- 모바일 UX: textarea + AutoResize hook (Shift+Enter 줄바꿈/Enter 전송), ScrollBottom 개선
- CSS: 로그인 페이지, 모드 버튼, 에러+retry UI, 디버그 배지 스타일 추가
- config: AUTH_PASSWORD 환경변수 지원