### PR TITLE
DM 메시지에 마크다운 렌더링 적용

### DIFF
--- a/lib/trpg_master_web/components/game_components.ex
+++ b/lib/trpg_master_web/components/game_components.ex
@@ -118,15 +118,72 @@ defmodule TrpgMasterWeb.GameComponents do
     """
   end
 
-  # 텍스트의 줄바꿈을 <br>로 변환
+  # 마크다운을 HTML로 변환
   defp format_text(text) when is_binary(text) do
     text
     |> Phoenix.HTML.html_escape()
     |> Phoenix.HTML.safe_to_string()
-    |> String.replace("\n", "<br>")
+    |> markdown_to_html()
   end
 
   defp format_text(_), do: ""
+
+  defp markdown_to_html(text) do
+    text
+    |> String.split("\n")
+    |> parse_lines()
+    |> Enum.join("\n")
+  end
+
+  defp parse_lines(lines) do
+    {result, acc} = Enum.reduce(lines, {[], nil}, fn line, {result, list_state} ->
+      cond do
+        # 수평선
+        Regex.match?(~r/^(---|\*\*\*|___)$/, line) ->
+          {flush_list(result, list_state) ++ ["<hr>"], nil}
+
+        # 헤더 (## 또는 ###)
+        Regex.match?(~r/^\#{1,6} /, line) ->
+          [hashes | rest] = String.split(line, " ", parts: 2)
+          level = min(String.length(hashes), 6)
+          tag = "h#{level}"
+          content = List.first(rest) |> inline_format()
+          {flush_list(result, list_state) ++ ["<#{tag}>#{content}</#{tag}>"], nil}
+
+        # 불릿 리스트 항목
+        Regex.match?(~r/^[-*] /, line) ->
+          item = String.slice(line, 2..-1//1) |> inline_format()
+          {result, (list_state || []) ++ ["<li>#{item}</li>"]}
+
+        # 빈 줄
+        String.trim(line) == "" ->
+          {flush_list(result, list_state) ++ [""], nil}
+
+        # 일반 텍스트
+        true ->
+          {flush_list(result, list_state) ++ [inline_format(line)], nil}
+      end
+    end)
+
+    flush_list(result, acc)
+  end
+
+  defp flush_list(result, nil), do: result
+  defp flush_list(result, items), do: result ++ ["<ul>" <> Enum.join(items) <> "</ul>"]
+
+  defp inline_format(text) do
+    text
+    # bold + italic: ***text***
+    |> String.replace(~r/\*\*\*(.+?)\*\*\*/, "<strong><em>\\1</em></strong>")
+    # bold: **text**
+    |> String.replace(~r/\*\*(.+?)\*\*/, "<strong>\\1</strong>")
+    # italic: *text* (단어 경계 처리)
+    |> String.replace(~r/\*([^\*]+)\*/, "<em>\\1</em>")
+    # italic: _text_
+    |> String.replace(~r/_([^_]+)_/, "<em>\\1</em>")
+    # 코드: `text`
+    |> String.replace(~r/`([^`]+)`/, "<code>\\1</code>")
+  end
 
   # 주문 슬롯 표시 (예: "1/3")
   defp spell_slots_display(character) do

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -184,6 +184,53 @@ html, body {
   word-break: break-word;
 }
 
+/* DM 메시지 마크다운 스타일 */
+.dm-message .message-body strong {
+  color: var(--accent-gold);
+  font-weight: 700;
+}
+
+.dm-message .message-body em {
+  color: #c8b8a2;
+  font-style: italic;
+}
+
+.dm-message .message-body h1,
+.dm-message .message-body h2,
+.dm-message .message-body h3,
+.dm-message .message-body h4 {
+  color: var(--accent-gold);
+  font-weight: 700;
+  margin: 0.4em 0 0.2em;
+  font-size: 1em;
+  letter-spacing: 0.03em;
+}
+
+.dm-message .message-body ul {
+  margin: 0.3em 0;
+  padding-left: 1.2em;
+  list-style: disc;
+}
+
+.dm-message .message-body li {
+  margin: 0.1em 0;
+}
+
+.dm-message .message-body code {
+  background: rgba(255,255,255,0.08);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9em;
+}
+
+.dm-message .message-body hr {
+  border: none;
+  border-top: 1px solid var(--accent-gold);
+  opacity: 0.3;
+  margin: 0.5em 0;
+}
+
 /* Dice */
 .dice-icon {
   font-size: 1.2rem;


### PR DESCRIPTION
외부 라이브러리 없이 inline 마크다운 파서를 구현하여
DM 채팅 메시지에 bold, italic, 헤더, 리스트, 코드, 수평선을 지원.
CSS도 게임 테마(골드 색상)에 맞춰 스타일링.