### PR TITLE
API rate limit 대응: prompt caching, 히스토리 축소, rate limiter 추가

### DIFF
--- a/lib/trpg_master/ai/client.ex
+++ b/lib/trpg_master/ai/client.ex
@@ -5,10 +5,11 @@ defmodule TrpgMaster.AI.Client do
   에러 발생 시 자동 재시도 (토큰 한도, rate limit, 서버 에러).
   """
 
+  alias TrpgMaster.AI.RateLimiter
   require Logger
 
   @api_url "https://api.anthropic.com/v1/messages"
-  @max_tool_iterations 10
+  @max_tool_iterations 5
   @timeout 120_000
 
   @doc """
@@ -32,12 +33,20 @@ defmodule TrpgMaster.AI.Client do
       selected_model = Keyword.get(opts, :model, model())
       max_tokens = Keyword.get(opts, :max_tokens, 4096)
 
+      # 시스템 프롬프트를 캐시 가능한 배열 형태로 변환
+      system_blocks = [
+        %{type: "text", text: system_prompt, cache_control: %{type: "ephemeral"}}
+      ]
+
+      # 도구 정의의 마지막 항목에 cache_control 추가
+      cached_tools = add_cache_control_to_tools(tools)
+
       body = %{
         model: selected_model,
         max_tokens: max_tokens,
-        system: system_prompt,
+        system: system_blocks,
         messages: messages,
-        tools: tools
+        tools: cached_tools
       }
 
       do_chat_with_retry(api_key, body, 0)
@@ -92,6 +101,14 @@ defmodule TrpgMaster.AI.Client do
     {:error, reason}
   end
 
+  # 도구 정의의 마지막 항목에 cache_control을 추가하여 캐싱 활성화
+  defp add_cache_control_to_tools([]), do: []
+
+  defp add_cache_control_to_tools(tools) when is_list(tools) do
+    {last, rest} = List.pop_at(tools, -1)
+    rest ++ [Map.put(last, :cache_control, %{type: "ephemeral"})]
+  end
+
   # 히스토리를 절반으로 줄이는 공격적 트리밍
   defp aggressive_trim_history(body) do
     messages = body.messages
@@ -117,21 +134,37 @@ defmodule TrpgMaster.AI.Client do
   end
 
   defp do_chat_loop(api_key, body, tool_results, iterations_left, usage) do
-    case call_api(api_key, body) do
-      {:ok, response} ->
-        new_usage = %{
-          input_tokens: usage.input_tokens + get_in(response, ["usage", "input_tokens"]) || 0,
-          output_tokens: usage.output_tokens + get_in(response, ["usage", "output_tokens"]) || 0
-        }
+    # Rate limiter: API 호출 전 토큰 사용량 확인 및 대기
+    case RateLimiter.check_and_wait() do
+      :ok ->
+        case call_api(api_key, body) do
+          {:ok, response} ->
+            input_tokens = get_in(response, ["usage", "input_tokens"]) || 0
+            output_tokens = get_in(response, ["usage", "output_tokens"]) || 0
 
-        Logger.info(
-          "Claude API 호출 — 입력: #{get_in(response, ["usage", "input_tokens"])}토큰, 출력: #{get_in(response, ["usage", "output_tokens"])}토큰"
-        )
+            # Rate limiter에 실제 사용량 기록
+            RateLimiter.record_usage(input_tokens)
 
-        handle_response(api_key, body, response, tool_results, iterations_left, new_usage)
+            new_usage = %{
+              input_tokens: usage.input_tokens + input_tokens,
+              output_tokens: usage.output_tokens + output_tokens
+            }
 
-      {:error, reason} ->
-        {:error, reason}
+            cache_read = get_in(response, ["usage", "cache_read_input_tokens"]) || 0
+            cache_create = get_in(response, ["usage", "cache_creation_input_tokens"]) || 0
+
+            Logger.info(
+              "Claude API 호출 — 입력: #{input_tokens}토큰, 출력: #{output_tokens}토큰, 캐시읽기: #{cache_read}토큰, 캐시생성: #{cache_create}토큰"
+            )
+
+            handle_response(api_key, body, response, tool_results, iterations_left, new_usage)
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, :rate_limited} ->
+        {:error, :rate_limited}
     end
   end
 
@@ -222,6 +255,7 @@ defmodule TrpgMaster.AI.Client do
     headers = [
       {~c"x-api-key", String.to_charlist(api_key)},
       {~c"anthropic-version", ~c"2023-06-01"},
+      {~c"anthropic-beta", ~c"prompt-caching-2024-07-31"},
       {~c"content-type", ~c"application/json"}
     ]
 
@@ -295,6 +329,7 @@ defmodule TrpgMaster.AI.Client do
   def format_error(:timeout), do: "AI 응답이 너무 오래 걸리고 있습니다. 다시 시도해주세요."
   def format_error(:connection_failed), do: "네트워크 연결에 실패했습니다. 인터넷 연결을 확인해주세요."
   def format_error(:max_tool_iterations), do: "도구 실행이 너무 많아 중단되었습니다. 다시 시도해주세요."
+  def format_error(:rate_limited), do: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
 
   def format_error({:api_error, 400, body}) do
     msg = get_in(body, ["error", "message"]) || ""

--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -8,8 +8,9 @@ defmodule TrpgMaster.AI.PromptBuilder do
   @system_prompt_path "priv/prompts/system_dm.md"
 
   # 토큰 예산 (한국어 위주: ~1토큰/2문자 보수적 추정)
-  # Claude Sonnet 기준 200K 컨텍스트에서 응답 4K 예약, 시스템 프롬프트 10K 예약 후 남은 예산
-  @max_history_tokens 40_000
+  # 분당 30K 토큰 rate limit 기준: 시스템 프롬프트(3K) + 도구(8K) + 히스토리 = ~23K 이내 유지
+  # prompt caching 적용 시 시스템+도구는 캐시되므로 추후 상향 가능
+  @max_history_tokens 12_000
 
   require Logger
 

--- a/lib/trpg_master/ai/rate_limiter.ex
+++ b/lib/trpg_master/ai/rate_limiter.ex
@@ -1,0 +1,115 @@
+defmodule TrpgMaster.AI.RateLimiter do
+  @moduledoc """
+  ETS 기반 슬라이딩 윈도우 rate limiter.
+  분당 입력 토큰 사용량을 추적하고 한도 초과 시 대기한다.
+  """
+
+  use GenServer
+  require Logger
+
+  @table :ai_rate_limiter
+  @window_ms 60_000
+  @default_token_limit 25_000
+  @max_wait_ms 30_000
+
+  # ── Public API ──────────────────────────────────────────────────────────────
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  API 호출 전 rate limit을 확인한다.
+  한도 근접 시 필요한 만큼 대기한 후 :ok를 반환한다.
+  대기 시간이 @max_wait_ms를 초과하면 {:error, :rate_limited}를 반환한다.
+  """
+  def check_and_wait(estimated_tokens \\ 0) do
+    token_limit = token_limit()
+    now = System.monotonic_time(:millisecond)
+    cleanup_old_entries(now)
+
+    current_usage = current_window_usage(now)
+
+    if current_usage + estimated_tokens <= token_limit do
+      :ok
+    else
+      wait_ms = estimate_wait_time(now, estimated_tokens, token_limit)
+
+      if wait_ms > @max_wait_ms do
+        Logger.warning("Rate limit 대기 시간 초과 (#{wait_ms}ms) — 요청 거부")
+        {:error, :rate_limited}
+      else
+        Logger.info("Rate limit 근접 — #{wait_ms}ms 대기 (현재: #{current_usage}/#{token_limit} 토큰)")
+        Process.sleep(wait_ms)
+        :ok
+      end
+    end
+  end
+
+  @doc """
+  API 호출 후 실제 사용한 토큰을 기록한다.
+  """
+  def record_usage(input_tokens) when is_integer(input_tokens) and input_tokens > 0 do
+    now = System.monotonic_time(:millisecond)
+    :ets.insert(@table, {now, input_tokens})
+    :ok
+  end
+
+  def record_usage(_), do: :ok
+
+  @doc """
+  현재 윈도우의 토큰 사용량을 조회한다.
+  """
+  def current_usage do
+    now = System.monotonic_time(:millisecond)
+    cleanup_old_entries(now)
+    current_window_usage(now)
+  end
+
+  # ── GenServer Callbacks ─────────────────────────────────────────────────────
+
+  @impl true
+  def init(_) do
+    table = :ets.new(@table, [:named_table, :ordered_set, :public, read_concurrency: true])
+    {:ok, %{table: table}}
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  defp current_window_usage(now) do
+    cutoff = now - @window_ms
+
+    :ets.foldl(
+      fn {ts, tokens}, acc ->
+        if ts > cutoff, do: acc + tokens, else: acc
+      end,
+      0,
+      @table
+    )
+  end
+
+  defp cleanup_old_entries(now) do
+    cutoff = now - @window_ms
+
+    :ets.select_delete(@table, [
+      {{:"$1", :_}, [{:<, :"$1", cutoff}], [true]}
+    ])
+  end
+
+  defp estimate_wait_time(now, _estimated_tokens, _token_limit) do
+    cutoff = now - @window_ms
+
+    oldest_entry =
+      case :ets.first(@table) do
+        :"$end_of_table" -> now
+        key when key > cutoff -> key
+        key -> key
+      end
+
+    max(1000, oldest_entry + @window_ms - now + 1000)
+  end
+
+  defp token_limit do
+    Application.get_env(:trpg_master, :rate_limit_tokens_per_minute, @default_token_limit)
+  end
+end

--- a/lib/trpg_master/application.ex
+++ b/lib/trpg_master/application.ex
@@ -9,6 +9,7 @@ defmodule TrpgMaster.Application do
       TrpgMasterWeb.Telemetry,
       {Phoenix.PubSub, name: TrpgMaster.PubSub},
       {DNSCluster, query: Application.get_env(:trpg_master, :dns_cluster_query) || :ignore},
+      TrpgMaster.AI.RateLimiter,
       TrpgMaster.Rules.Loader,
       TrpgMaster.Oracle.Loader,
       {Registry, keys: :unique, name: TrpgMaster.Campaign.Registry},


### PR DESCRIPTION
- prompt caching 활성화: 시스템 프롬프트와 도구 정의에 cache_control 적용하여 반복 호출 시 입력 토큰 절감
- 히스토리 토큰 예산 40K → 12K로 축소하여 단일 호출 크기 제한
- ETS 기반 슬라이딩 윈도우 rate limiter 추가: 분당 토큰 사용량 추적 및 선제적 throttling
- tool use 최대 반복 횟수 10 → 5로 축소
- 캐시 토큰 사용량 로깅 추가