### PR TITLE
채팅창 플레이어 이름 표시 개선: 캐릭터 설정 후 '플레이어' 대신 캐릭터 이름 표시

### DIFF
--- a/lib/trpg_master_web/components/game_components.ex
+++ b/lib/trpg_master_web/components/game_components.ex
@@ -23,11 +23,12 @@ defmodule TrpgMasterWeb.GameComponents do
   플레이어 메시지 컴포넌트.
   """
   attr :text, :string, required: true
+  attr :name, :string, default: "플레이어"
 
   def player_message(assigns) do
     ~H"""
     <div class="message player-message">
-      <div class="message-header">플레이어</div>
+      <div class="message-header"><%= @name %></div>
       <div class="message-body"><%= @text %></div>
     </div>
     """

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -221,7 +221,7 @@ defmodule TrpgMasterWeb.CampaignLive do
             <% :dm -> %>
               <.dm_message text={msg.text} />
             <% :player -> %>
-              <.player_message text={msg.text} />
+              <.player_message text={msg.text} name={if @character, do: @character["name"] || "플레이어", else: "플레이어"} />
             <% :dice -> %>
               <.dice_result result={msg.result} />
             <% :system -> %>


### PR DESCRIPTION
## Summary
- 캐릭터 설정 전: "플레이어" 표시 (기존 동작 유지)
- 캐릭터 설정 후: 실제 캐릭터 이름 표시

## Changes
- `game_components.ex`: `player_message`에 `name` 속성 추가
- `campaign_live.ex`: 렌더링 시 `@character["name"]` 전달
