### PR TITLE
룰 데이터 참조 확장 및 전투 시 몬스터 데이터 활용 강화

### DIFF
--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -207,10 +207,32 @@ defmodule TrpgMaster.AI.PromptBuilder do
     cs = state.combat_state
     participants = (cs["participants"] || []) |> Enum.join(", ")
 
+    enemies_section =
+      case cs["enemies"] do
+        enemies when is_list(enemies) and enemies != [] ->
+          enemy_lines =
+            Enum.map(enemies, fn e ->
+              hp =
+                if e["hp_current"] && e["hp_max"],
+                  do: " HP #{e["hp_current"]}/#{e["hp_max"]}",
+                  else: ""
+
+              ac = if e["ac"], do: " AC #{e["ac"]}", else: ""
+              count = if e["count"] && e["count"] > 1, do: " x#{e["count"]}", else: ""
+              "  - #{e["name"]}#{count}#{hp}#{ac}"
+            end)
+            |> Enum.join("\n")
+
+          "\n- 적 현황:\n#{enemy_lines}"
+
+        _ ->
+          ""
+      end
+
     """
     ## 전투 진행 중
     - 라운드: #{cs["round"] || 1}
-    - 참가자: #{participants}
+    - 참가자: #{participants}#{enemies_section}
     """
   end
 

--- a/lib/trpg_master/ai/tools.ex
+++ b/lib/trpg_master/ai/tools.ex
@@ -25,7 +25,8 @@ defmodule TrpgMaster.AI.Tools do
       combat_prep_checklist_def(),
       combat_round_checklist_def(),
       combat_end_checklist_def(),
-      lookup_dc_def()
+      lookup_dc_def(),
+      lookup_rule_def()
     ]
   end
 
@@ -227,6 +228,30 @@ defmodule TrpgMaster.AI.Tools do
     }
   end
 
+  defp lookup_rule_def do
+    %{
+      name: "lookup_rule",
+      description:
+        "D&D 5e 규칙을 조회한다. 전투 규칙, 상태이상 효과, 행동 종류, 피해 유형/저항/면역, 기술 판정, 주문 시전 규칙 등을 확인할 때 사용. 예: \"기절\", \"집중\", \"기회 공격\", \"엄폐\", \"넘어짐\"",
+      input_schema: %{
+        type: "object",
+        properties: %{
+          query: %{
+            type: "string",
+            description:
+              "조회할 규칙 키워드. 예: \"기절(Stunned)\", \"집중(Concentration)\", \"공격 행동\", \"독 저항\""
+          },
+          category: %{
+            type: "string",
+            description:
+              "규칙 카테고리 (선택). 예: \"conditions\", \"combat\", \"actions\", \"damage-and-healing\", \"spellcasting\""
+          }
+        },
+        required: ["query"]
+      }
+    }
+  end
+
   # ── State-change tool definitions ────────────────────────────────────────────
 
   @doc """
@@ -331,7 +356,7 @@ defmodule TrpgMaster.AI.Tools do
     %{
       name: "start_combat",
       description:
-        "전투를 시작한다. 전투 참가자 목록과 함께 호출한다. 이 도구를 호출한 후 각 참가자의 주도권을 roll_dice로 굴린다.",
+        "전투를 시작한다. 호출 전에 반드시 모든 적에 대해 lookup_monster로 스탯을 조회해야 한다. 전투 참가자 목록과 함께 호출하고, 이후 각 참가자의 주도권을 roll_dice로 굴린다.",
       input_schema: %{
         type: "object",
         properties: %{
@@ -339,6 +364,21 @@ defmodule TrpgMaster.AI.Tools do
             type: "array",
             items: %{type: "string"},
             description: "전투 참가자 이름 목록"
+          },
+          enemies: %{
+            type: "array",
+            items: %{
+              type: "object",
+              properties: %{
+                name: %{type: "string"},
+                hp_max: %{type: "integer"},
+                hp_current: %{type: "integer"},
+                ac: %{type: "integer"},
+                count: %{type: "integer", description: "같은 종류 적 수 (기본 1)"}
+              }
+            },
+            description:
+              "전투에 등장하는 적 목록과 조회된 스탯. lookup_monster 후 이 필드를 채운다."
           }
         },
         required: ["participants"]
@@ -482,6 +522,21 @@ defmodule TrpgMaster.AI.Tools do
     {:ok, %{"oracles" => oracles}}
   end
 
+  def execute("lookup_rule", input) do
+    query = Map.get(input, "query", "")
+    category = Map.get(input, "category")
+
+    # category가 주어지면 해당 카테고리 문서를 먼저 시도
+    if category do
+      case RulesLoader.lookup(:rule, category) do
+        {:ok, entry} -> {:ok, entry}
+        :not_found -> lookup_rule(:rule, query)
+      end
+    else
+      lookup_rule(:rule, query)
+    end
+  end
+
   def execute("lookup_dc", input) do
     skill_or_attribute = Map.get(input, "skill_or_attribute", "")
     result = DCLoader.lookup(skill_or_attribute)
@@ -549,12 +604,15 @@ defmodule TrpgMaster.AI.Tools do
   def execute("combat_prep_checklist", _input) do
     checklist = """
     전투 준비 체크리스트:
+    0. 몬스터 스탯 조회: 등장하는 모든 적에 대해 lookup_monster를 즉시 호출한다.
+       조회한 AC, HP(최대치), 공격 수정치, 피해 주사위, 특수 능력을 기억하고 전투에 사용한다.
+       HP는 조회된 hp 값을 기준으로 실제 HP를 roll_dice로 굴려 결정한다 (또는 평균값 사용).
     1. 몬스터 목표: 각 적은 이 전투에서 무엇을 원하는가? (생존, 약탈, 영역 방어, 복수, 시간 벌기, 보호)
     2. 행동 패턴: 각 적의 전투 성향을 정한다 (매복, 비열한 전투, 리더 보호, 열세 시 도주)
     3. 환경 활용: 최소 2가지 환경 요소를 파악한다 (엄폐물, 위험 지형, 고도차, 어둠, 좁은 통로)
     4. 퇴각 경로: 몬스터가 도망칠 수 있는 경로를 설정한다
     5. 전리품/단서: 적이 소지하거나 떨어뜨릴 수 있는 아이템/정보를 정한다
-    위 항목을 각각 1~2문장으로 계획한 후, roll_dice로 주도권을 굴리고 전투를 시작하세요.
+    위 항목을 각각 1~2문장으로 계획한 후, start_combat의 enemies 필드에 조회된 스탯을 채워 호출하고, roll_dice로 주도권을 굴리세요.
     """
 
     {:ok, %{"checklist" => String.trim(checklist)}}

--- a/lib/trpg_master/campaign/server.ex
+++ b/lib/trpg_master/campaign/server.ex
@@ -318,6 +318,7 @@ defmodule TrpgMaster.Campaign.Server do
     end
 
     participants = input["participants"] || []
+    enemies = input["enemies"]
     Logger.info("전투 시작: #{Enum.join(participants, ", ")}")
 
     combat = %{
@@ -325,6 +326,13 @@ defmodule TrpgMaster.Campaign.Server do
       "round" => 1,
       "turn_order" => []
     }
+
+    combat =
+      if is_list(enemies) && enemies != [] do
+        Map.put(combat, "enemies", enemies)
+      else
+        combat
+      end
 
     %{state | phase: :combat, combat_state: combat}
   end

--- a/lib/trpg_master/rules/loader.ex
+++ b/lib/trpg_master/rules/loader.ex
@@ -49,6 +49,21 @@ defmodule TrpgMaster.Rules.Loader do
     {"adventuringGear.json", :item, :nameKo_name, "gear"}
   ]
 
+  # rules/*.json 파일: 각 파일은 {id, title, intro, sections} 구조의 단일 객체.
+  # :rule 타입으로 ETS에 저장. 문서 전체 + 개별 섹션 모두 키 등록.
+  @rules_file_map [
+    "rules/combat.json",
+    "rules/conditions.json",
+    "rules/actions.json",
+    "rules/damage-and-healing.json",
+    "rules/d20-tests.json",
+    "rules/abilities.json",
+    "rules/exploration.json",
+    "rules/proficiency.json",
+    "rules/social-interaction.json",
+    "rules/spellcasting.json"
+  ]
+
   # ── Public API ─────────────────────────────────────────────────────────────
 
   @doc "정확한 이름으로 조회. Returns {:ok, entry} | :not_found"
@@ -103,7 +118,9 @@ defmodule TrpgMaster.Rules.Loader do
   """
   def status do
     types = @file_type_map |> Enum.map(fn {_, t, _, _} -> t end) |> Enum.uniq()
-    Enum.map(types, fn type -> {type, list(type) |> length()} end)
+    type_counts = Enum.map(types, fn type -> {type, list(type) |> length()} end)
+    rule_count = list(:rule) |> length()
+    type_counts ++ [{:rule, rule_count}]
   end
 
   # ── GenServer callbacks ─────────────────────────────────────────────────────
@@ -160,11 +177,34 @@ defmodule TrpgMaster.Rules.Loader do
           load_local_file(table, filename, type, name_style, list_key)
       end
     end)
+
+    # rules/*.json 로드
+    Enum.each(@rules_file_map, fn filename ->
+      url = "#{@github_raw_base}/#{filename}"
+
+      case fetch_json(url, token) do
+        {:ok, raw} ->
+          count = insert_rule_document(table, raw)
+          Logger.info("Rules.Loader: [GitHub] #{filename} → rule #{count}개")
+
+        {:error, reason} ->
+          Logger.warning(
+            "Rules.Loader: [GitHub] #{filename} fetch 실패 (#{reason}) → 로컬 파일로 대체"
+          )
+
+          load_local_rule_file(table, filename)
+      end
+    end)
   end
 
   defp load_from_local(table) do
     Enum.each(@file_type_map, fn {filename, type, name_style, list_key} ->
       load_local_file(table, filename, type, name_style, list_key)
+    end)
+
+    # rules/*.json 로드
+    Enum.each(@rules_file_map, fn filename ->
+      load_local_rule_file(table, filename)
     end)
   end
 
@@ -294,6 +334,121 @@ defmodule TrpgMaster.Rules.Loader do
       _ -> {nil, nil}
     end
   end
+
+  # ── Rules document loading ──────────────────────────────────────────────────
+
+  defp load_local_rule_file(table, filename) do
+    rules_dir = Application.app_dir(:trpg_master, "priv/rules")
+    path = Path.join(rules_dir, filename)
+
+    if File.exists?(path) do
+      case File.read(path) do
+        {:ok, content} ->
+          case Jason.decode(content) do
+            {:ok, raw} ->
+              count = insert_rule_document(table, raw)
+              Logger.info("Rules.Loader: [로컬] #{filename} → rule #{count}개")
+
+            {:error, reason} ->
+              Logger.warning("Rules.Loader: #{path} JSON 파싱 실패 — #{inspect(reason)}")
+          end
+
+        {:error, reason} ->
+          Logger.warning("Rules.Loader: #{path} 읽기 실패 — #{inspect(reason)}")
+      end
+    else
+      Logger.info("Rules.Loader: #{path} 파일 없음. 건너뜁니다.")
+    end
+  end
+
+  # rules/*.json은 {id, title, intro, sections} 구조의 단일 문서.
+  # 문서 전체를 id로 저장하고, 각 section도 section.id로 저장한다.
+  # title의 ko/en 키도 등록하여 한국어/영어 검색을 지원한다.
+  defp insert_rule_document(table, %{"id" => doc_id, "sections" => sections} = doc)
+       when is_binary(doc_id) and is_list(sections) do
+    # 문서 전체를 doc_id로 저장
+    :ets.insert(table, {{:rule, normalize(doc_id)}, doc})
+    count = 1
+
+    # title의 한국어/영어 키 등록
+    title_count = insert_rule_title_keys(table, doc_id, doc)
+
+    # 각 섹션을 section.id로 저장
+    section_count =
+      Enum.reduce(sections, 0, fn section, acc ->
+        acc + insert_rule_section(table, section)
+      end)
+
+    count + title_count + section_count
+  end
+
+  defp insert_rule_document(_table, _doc), do: 0
+
+  defp insert_rule_title_keys(table, doc_id, doc) do
+    title = Map.get(doc, "title", %{})
+    ko = Map.get(title, "ko")
+    en = Map.get(title, "en")
+
+    ko_count =
+      if is_binary(ko) && ko != "" && normalize(ko) != normalize(doc_id) do
+        :ets.insert(table, {{:rule, normalize(ko)}, doc})
+        1
+      else
+        0
+      end
+
+    en_count =
+      if is_binary(en) && en != "" && normalize(en) != normalize(doc_id) do
+        :ets.insert(table, {{:rule, normalize(en)}, doc})
+        1
+      else
+        0
+      end
+
+    ko_count + en_count
+  end
+
+  defp insert_rule_section(table, %{"id" => section_id} = section)
+       when is_binary(section_id) do
+    :ets.insert(table, {{:rule, normalize(section_id)}, section})
+
+    # 섹션 title의 한국어/영어 키 등록
+    title = Map.get(section, "title", %{})
+    ko = Map.get(title, "ko")
+    en = Map.get(title, "en")
+
+    ko_count =
+      if is_binary(ko) && ko != "" && normalize(ko) != normalize(section_id) do
+        :ets.insert(table, {{:rule, normalize(ko)}, section})
+        1
+      else
+        0
+      end
+
+    en_count =
+      if is_binary(en) && en != "" && normalize(en) != normalize(section_id) do
+        :ets.insert(table, {{:rule, normalize(en)}, section})
+        1
+      else
+        0
+      end
+
+    # 재귀: 하위 content 중 subsection이 있으면 처리
+    sub_count =
+      case Map.get(section, "content") do
+        content when is_list(content) ->
+          content
+          |> Enum.filter(fn item -> is_map(item) && Map.get(item, "type") == "subsection" end)
+          |> Enum.reduce(0, fn sub, acc -> acc + insert_rule_section(table, sub) end)
+
+        _ ->
+          0
+      end
+
+    1 + ko_count + en_count + sub_count
+  end
+
+  defp insert_rule_section(_table, _section), do: 0
 
   # ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/priv/prompts/system_dm.md
+++ b/priv/prompts/system_dm.md
@@ -73,9 +73,15 @@
 - 몬스터 등장 시 반드시 lookup_monster로 스탯을 확인합니다.
 - 클래스 특성이 필요할 때 lookup_class를 사용합니다.
 - 아이템 확인 시 lookup_item을 사용합니다.
+- **규칙 판정이 필요할 때 lookup_rule을 사용합니다:**
+  - 전투 중 상태이상 효과 적용 시 → `lookup_rule(query: "기절")` 또는 `lookup_rule(query: "Stunned", category: "conditions")`
+  - 기회 공격, 집중, 엄폐 등 전투 규칙 → `lookup_rule(query: "기회 공격", category: "combat")`
+  - 피해 저항/면역 판단 시 → `lookup_rule(query: "피해 저항", category: "damage-and-healing")`
+  - 주문 시전 규칙 확인 시 → `lookup_rule(query: "집중", category: "spellcasting")`
+  - 능력치 판정/내성 굴림 규칙 → `lookup_rule(query: "ability checks", category: "d20-tests")`
 - 조회 결과에 "error" 필드가 있으면 번역 데이터에 없는 것입니다. D&D 5e 2024 규칙 기준으로 판단하고, "번역 데이터에 없어서 룰북 기준으로 판단했습니다"라고 고지합니다.
 - 여러 도구를 한 턴에 조합해서 사용할 수 있습니다.
-  예: 전투 시작 시 lookup_monster + roll_dice(주도권)을 연속 호출.
+  예: 전투 시작 시 lookup_monster + lookup_rule(category: "combat") + roll_dice(주도권)을 연속 호출.
 
 ## 룰 판단 우선순위
 


### PR DESCRIPTION
- rules/*.json 10개 파일을 :rule 타입으로 ETS에 로드 (문서/섹션/서브섹션 단위 키 등록)
- lookup_rule 도구 추가: 전투 규칙, 상태이상, 행동, 피해 유형 등 D&D 5e 규칙 조회
- combat_prep_checklist에 lookup_monster 스탯 조회 단계(0번) 추가
- start_combat에 enemies 필드 추가: 적 HP/AC/수량을 combat_state에 저장
- combat_section 시스템 프롬프트에 적 현황(이름/HP/AC) 표시
- system_dm.md에 lookup_rule 사용 가이드 추가