### PR TITLE
feat: DM 선택 기능 - Anthropic/OpenAI/Gemini 멀티 프로바이더 지원

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,8 +2,10 @@ import Config
 
 config :trpg_master,
   anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+  openai_api_key: System.get_env("OPENAI_API_KEY"),
+  google_api_key: System.get_env("GOOGLE_API_KEY"),
   data_dir: System.get_env("DATA_DIR", "data"),
-  ai_model: System.get_env("AI_MODEL", "claude-sonnet-4-20250514"),
+  ai_model: System.get_env("AI_MODEL", "claude-sonnet-4-6"),
   auth_password: System.get_env("AUTH_PASSWORD")
 
 if config_env() == :prod do

--- a/lib/trpg_master/ai/client.ex
+++ b/lib/trpg_master/ai/client.ex
@@ -1,23 +1,17 @@
 defmodule TrpgMaster.AI.Client do
   @moduledoc """
-  Claude API 호출 + tool use 루프.
-  Erlang :httpc를 사용하여 외부 HTTP 의존성 없이 구현.
-  에러 발생 시 자동 재시도 (토큰 한도, rate limit, 서버 에러).
+  AI 프로바이더 facade.
+  모델에 따라 적절한 프로바이더 모듈로 요청을 위임한다.
   """
 
-  alias TrpgMaster.AI.RateLimiter
-  require Logger
-
-  @api_url "https://api.anthropic.com/v1/messages"
-  @max_tool_iterations 5
-  @timeout 120_000
+  alias TrpgMaster.AI.Models
 
   @doc """
-  Claude API에 메시지를 보내고 응답을 받는다.
-  tool use가 발생하면 도구를 실행하고 자동으로 재호출한다.
+  AI API에 메시지를 보내고 응답을 받는다.
+  모델 설정에 따라 Anthropic, OpenAI, Gemini 중 하나로 요청을 보낸다.
 
   옵션:
-    - model: 사용할 Claude 모델 (기본값: 설정된 모델)
+    - model: 사용할 모델 ID (기본값: 설정된 기본 모델)
     - max_tokens: 최대 출력 토큰 (기본값: 4096)
 
   반환값:
@@ -25,330 +19,31 @@ defmodule TrpgMaster.AI.Client do
     {:error, term()}
   """
   def chat(system_prompt, messages, tools \\ [], opts \\ []) do
-    api_key = Application.get_env(:trpg_master, :anthropic_api_key)
+    model_id = Keyword.get(opts, :model, Models.default_model())
 
-    if is_nil(api_key) || api_key == "" do
-      {:error, :no_api_key}
-    else
-      selected_model = Keyword.get(opts, :model, model())
-      max_tokens = Keyword.get(opts, :max_tokens, 4096)
+    case Models.find(model_id) do
+      nil ->
+        {:error, :unknown_model}
 
-      # 시스템 프롬프트를 캐시 가능한 배열 형태로 변환
-      system_blocks = [
-        %{type: "text", text: system_prompt, cache_control: %{type: "ephemeral"}}
-      ]
-
-      # 도구 정의의 마지막 항목에 cache_control 추가
-      cached_tools = add_cache_control_to_tools(tools)
-
-      body = %{
-        model: selected_model,
-        max_tokens: max_tokens,
-        system: system_blocks,
-        messages: messages,
-        tools: cached_tools
-      }
-
-      do_chat_with_retry(api_key, body, 0)
-    end
-  end
-
-  # ── 재시도 래퍼 ─────────────────────────────────────────────────────────────
-
-  defp do_chat_with_retry(api_key, body, retry_count) do
-    case do_chat_loop(api_key, body, [], @max_tool_iterations, %{
-           input_tokens: 0,
-           output_tokens: 0
-         }) do
-      {:ok, result} ->
-        {:ok, result}
-
-      {:error, reason} ->
-        handle_api_error(api_key, body, reason, retry_count)
-    end
-  end
-
-  defp handle_api_error(api_key, body, {:api_error, 400, _error_body}, retry_count)
-       when retry_count < 2 do
-    # 토큰 한도 초과 — 히스토리를 공격적으로 트리밍 후 재시도
-    Logger.warning("API 400 오류 — 히스토리 트리밍 후 재시도 (#{retry_count + 1}/2)")
-    trimmed_body = aggressive_trim_history(body)
-    do_chat_with_retry(api_key, trimmed_body, retry_count + 1)
-  end
-
-  defp handle_api_error(api_key, body, {:api_error, 429, _error_body}, retry_count)
-       when retry_count < 3 do
-    # Rate limit — 지수 백오프 후 재시도
-    wait_ms = 2000 * (retry_count + 1)
-    Logger.warning("Rate limit — #{wait_ms}ms 대기 후 재시도 (#{retry_count + 1}/3)")
-    Process.sleep(wait_ms)
-    do_chat_with_retry(api_key, body, retry_count + 1)
-  end
-
-  defp handle_api_error(api_key, body, {:api_error, status, _error_body}, retry_count)
-       when status in [500, 529] and retry_count < 2 do
-    # 서버 에러 — 잠시 대기 후 재시도
-    Logger.warning("서버 에러 #{status} — 3초 대기 후 재시도 (#{retry_count + 1}/2)")
-    Process.sleep(3000)
-    do_chat_with_retry(api_key, body, retry_count + 1)
-  end
-
-  defp handle_api_error(_api_key, _body, {:api_error, 401, _}, _retry_count) do
-    {:error, :invalid_api_key}
-  end
-
-  defp handle_api_error(_api_key, _body, reason, _retry_count) do
-    {:error, reason}
-  end
-
-  # 도구 정의의 마지막 항목에 cache_control을 추가하여 캐싱 활성화
-  defp add_cache_control_to_tools([]), do: []
-
-  defp add_cache_control_to_tools(tools) when is_list(tools) do
-    {last, rest} = List.pop_at(tools, -1)
-
-    if Map.has_key?(last, :cache_control) || Map.has_key?(last, "cache_control") do
-      tools
-    else
-      rest ++ [Map.put(last, :cache_control, %{type: "ephemeral"})]
-    end
-  end
-
-  # 히스토리를 절반으로 줄이는 공격적 트리밍
-  defp aggressive_trim_history(body) do
-    messages = body.messages
-    take_count = min(max(div(length(messages), 2), 2), length(messages))
-    # 최신 메시지의 절반만 유지, user 메시지로 시작해야 함
-    trimmed = Enum.take(messages, -take_count)
-
-    trimmed =
-      case trimmed do
-        [%{role: "assistant"} | rest] -> rest
-        other -> other
-      end
-
-    Logger.info("공격적 트리밍: #{length(messages)}개 → #{length(trimmed)}개")
-    %{body | messages: trimmed}
-  end
-
-  # ── Chat loop ───────────────────────────────────────────────────────────────
-  # Claude 응답이 tool_use를 포함하면 도구를 실행하고 결과를 포함하여 재호출한다.
-  # 최대 @max_tool_iterations회 반복 후 중단. stop_reason이 "end_turn"이면 종료.
-
-  defp do_chat_loop(_api_key, _body, _tool_results, 0, _usage) do
-    Logger.warning("Tool use 최대 반복 횟수 초과")
-    {:error, :max_tool_iterations}
-  end
-
-  defp do_chat_loop(api_key, body, tool_results, iterations_left, usage) do
-    # Rate limiter: API 호출 전 토큰 사용량 확인 및 대기
-    case RateLimiter.check_and_wait() do
-      :ok ->
-        case call_api(api_key, body) do
-          {:ok, response} ->
-            input_tokens = get_in(response, ["usage", "input_tokens"]) || 0
-            output_tokens = get_in(response, ["usage", "output_tokens"]) || 0
-
-            # Rate limiter에 실제 사용량 기록
-            RateLimiter.record_usage(input_tokens)
-
-            new_usage = %{
-              input_tokens: usage.input_tokens + input_tokens,
-              output_tokens: usage.output_tokens + output_tokens
-            }
-
-            cache_read = get_in(response, ["usage", "cache_read_input_tokens"]) || 0
-            cache_create = get_in(response, ["usage", "cache_creation_input_tokens"]) || 0
-
-            Logger.info(
-              "Claude API 호출 — 입력: #{input_tokens}토큰, 출력: #{output_tokens}토큰, 캐시읽기: #{cache_read}토큰, 캐시생성: #{cache_create}토큰"
-            )
-
-            handle_response(api_key, body, response, tool_results, iterations_left, new_usage)
-
-          {:error, reason} ->
-            {:error, reason}
+      model_info ->
+        if Models.api_key_configured?(model_id) do
+          provider_module(model_info.provider).chat(system_prompt, messages, tools, opts)
+        else
+          {:error, {:no_api_key, model_info.env}}
         end
-
-      {:error, :rate_limited} ->
-        {:error, :rate_limited}
     end
   end
 
-  defp handle_response(api_key, body, response, tool_results, iterations_left, usage) do
-    content = Map.get(response, "content", [])
-    stop_reason = Map.get(response, "stop_reason")
-
-    text_parts =
-      content
-      |> Enum.filter(&(&1["type"] == "text"))
-      |> Enum.map(& &1["text"])
-
-    tool_use_blocks =
-      content
-      |> Enum.filter(&(&1["type"] == "tool_use"))
-
-    if stop_reason == "tool_use" && length(tool_use_blocks) > 0 do
-      {new_tool_results, tool_result_blocks} = execute_tools(tool_use_blocks)
-
-      updated_messages =
-        body.messages ++
-          [
-            %{role: "assistant", content: content},
-            %{role: "user", content: tool_result_blocks}
-          ]
-
-      updated_body = %{body | messages: updated_messages}
-
-      do_chat_loop(
-        api_key,
-        updated_body,
-        tool_results ++ new_tool_results,
-        iterations_left - 1,
-        usage
-      )
-    else
-      final_text = Enum.join(text_parts, "\n")
-
-      {:ok,
-       %{
-         text: final_text,
-         tool_results: tool_results,
-         usage: usage
-       }}
-    end
-  end
-
-  defp execute_tools(tool_use_blocks) do
-    results =
-      Enum.map(tool_use_blocks, fn block ->
-        tool_name = block["name"]
-        tool_input = block["input"]
-        tool_use_id = block["id"]
-
-        Logger.info("도구 실행: #{tool_name} — #{inspect(tool_input)}")
-
-        case TrpgMaster.AI.Tools.execute(tool_name, tool_input) do
-          {:ok, result} ->
-            {%{tool: tool_name, input: tool_input, result: result},
-             %{
-               type: "tool_result",
-               tool_use_id: tool_use_id,
-               content: Jason.encode!(result)
-             }}
-
-          {:error, reason} ->
-            {%{tool: tool_name, input: tool_input, error: reason},
-             %{
-               type: "tool_result",
-               tool_use_id: tool_use_id,
-               is_error: true,
-               content: "오류: #{reason}"
-             }}
-        end
-      end)
-
-    {Enum.map(results, &elem(&1, 0)), Enum.map(results, &elem(&1, 1))}
-  end
-
-  # ── HTTP ────────────────────────────────────────────────────────────────────
-
-  defp call_api(api_key, body) do
-    :ssl.start()
-    :inets.start()
-
-    json_body = Jason.encode!(body)
-
-    headers = [
-      {~c"x-api-key", String.to_charlist(api_key)},
-      {~c"anthropic-version", ~c"2023-06-01"},
-      {~c"anthropic-beta", ~c"prompt-caching-2024-07-31"},
-      {~c"content-type", ~c"application/json"}
-    ]
-
-    ssl_opts = ssl_options()
-
-    http_opts = [
-      timeout: @timeout,
-      connect_timeout: 10_000,
-      ssl: ssl_opts
-    ]
-
-    request = {String.to_charlist(@api_url), headers, ~c"application/json", json_body}
-
-    case :httpc.request(:post, request, http_opts, []) do
-      {:ok, {{_, status, _}, _headers, resp_body}} when status in 200..299 ->
-        case Jason.decode(:erlang.list_to_binary(resp_body)) do
-          {:ok, parsed} -> {:ok, parsed}
-          {:error, reason} -> {:error, {:json_parse_error, reason}}
-        end
-
-      {:ok, {{_, status, _}, _headers, resp_body}} ->
-        body_str = :erlang.list_to_binary(resp_body)
-        Logger.error("Claude API 오류 #{status}: #{body_str}")
-
-        error_body =
-          case Jason.decode(body_str) do
-            {:ok, parsed} -> parsed
-            _ -> %{"raw" => String.slice(body_str, 0, 300)}
-          end
-
-        {:error, {:api_error, status, error_body}}
-
-      {:error, {:failed_connect, _}} ->
-        {:error, :connection_failed}
-
-      {:error, :timeout} ->
-        {:error, :timeout}
-
-      {:error, reason} ->
-        Logger.error("HTTP 요청 실패: #{inspect(reason)}")
-        {:error, {:http_error, reason}}
-    end
-  end
-
-  defp ssl_options do
-    ca_cert_file = System.get_env("SSL_CERT_FILE") || find_cacert_file()
-
-    if File.exists?(ca_cert_file) do
-      [
-        verify: :verify_peer,
-        cacertfile: String.to_charlist(ca_cert_file),
-        depth: 10,
-        customize_hostname_check: [
-          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-        ]
-      ]
-    else
-      [verify: :verify_none]
-    end
-  end
-
-  defp find_cacert_file do
-    paths = [
-      # Linux (Debian/Ubuntu)
-      "/etc/ssl/certs/ca-certificates.crt",
-      # Linux (RHEL/CentOS/Fedora)
-      "/etc/pki/tls/certs/ca-bundle.crt",
-      # macOS (Homebrew - Apple Silicon)
-      "/opt/homebrew/etc/openssl/cert.pem",
-      # macOS (Homebrew - Intel)
-      "/usr/local/etc/openssl/cert.pem",
-      # macOS (system)
-      "/etc/ssl/cert.pem"
-    ]
-
-    Enum.find(paths, List.first(paths), &File.exists?/1)
-  end
-
-  defp model do
-    Application.get_env(:trpg_master, :ai_model, "claude-sonnet-4-20250514")
-  end
+  defp provider_module(:anthropic), do: TrpgMaster.AI.Providers.Anthropic
+  defp provider_module(:openai), do: TrpgMaster.AI.Providers.OpenAI
+  defp provider_module(:gemini), do: TrpgMaster.AI.Providers.Gemini
 
   @doc """
   API 에러 atom/tuple을 사용자 친화적인 한국어 메시지로 변환한다.
   """
-  def format_error(:no_api_key), do: "ANTHROPIC_API_KEY가 설정되지 않았습니다."
+  def format_error(:no_api_key), do: "API 키가 설정되지 않았습니다."
+  def format_error({:no_api_key, env_var}), do: "#{env_var} API 키가 설정되지 않았습니다."
+  def format_error(:unknown_model), do: "알 수 없는 AI 모델입니다."
   def format_error(:invalid_api_key), do: "API 키가 올바르지 않습니다. 설정을 확인해주세요."
   def format_error(:timeout), do: "AI 응답이 너무 오래 걸리고 있습니다. 다시 시도해주세요."
   def format_error(:connection_failed), do: "네트워크 연결에 실패했습니다. 인터넷 연결을 확인해주세요."

--- a/lib/trpg_master/ai/models.ex
+++ b/lib/trpg_master/ai/models.ex
@@ -1,0 +1,92 @@
+defmodule TrpgMaster.AI.Models do
+  @moduledoc """
+  지원하는 AI 모델 목록과 API 키 가용성을 관리한다.
+  """
+
+  @models [
+    %{
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      provider: :anthropic,
+      env: "ANTHROPIC_API_KEY",
+      config_key: :anthropic_api_key
+    },
+    %{
+      id: "claude-haiku-4-5-20251001",
+      name: "Claude Haiku 4.5",
+      provider: :anthropic,
+      env: "ANTHROPIC_API_KEY",
+      config_key: :anthropic_api_key
+    },
+    %{
+      id: "gpt-4.1",
+      name: "GPT-4.1",
+      provider: :openai,
+      env: "OPENAI_API_KEY",
+      config_key: :openai_api_key
+    },
+    %{
+      id: "gpt-4.1-mini",
+      name: "GPT-4.1 Mini",
+      provider: :openai,
+      env: "OPENAI_API_KEY",
+      config_key: :openai_api_key
+    },
+    %{
+      id: "gemini-2.5-pro",
+      name: "Gemini 2.5 Pro",
+      provider: :gemini,
+      env: "GOOGLE_API_KEY",
+      config_key: :google_api_key
+    },
+    %{
+      id: "gemini-2.5-flash",
+      name: "Gemini 2.5 Flash",
+      provider: :gemini,
+      env: "GOOGLE_API_KEY",
+      config_key: :google_api_key
+    }
+  ]
+
+  @doc "전체 모델 목록 반환"
+  def all, do: @models
+
+  @doc "모델 ID로 모델 정보 조회"
+  def find(model_id), do: Enum.find(@models, &(&1.id == model_id))
+
+  @doc "모델 ID에 해당하는 프로바이더 atom 반환"
+  def provider_for(model_id) do
+    case find(model_id) do
+      nil -> nil
+      model -> model.provider
+    end
+  end
+
+  @doc "해당 모델의 API 키가 설정되어 있는지 확인"
+  def api_key_configured?(model_id) do
+    case find(model_id) do
+      nil -> false
+      model ->
+        key = Application.get_env(:trpg_master, model.config_key)
+        not (is_nil(key) or key == "")
+    end
+  end
+
+  @doc "각 모델에 available 상태를 포함한 목록 반환"
+  def list_with_status do
+    Enum.map(@models, fn model ->
+      Map.put(model, :available, api_key_configured?(model.id))
+    end)
+  end
+
+  @doc "현재 설정된 기본 모델 ID 반환"
+  def default_model do
+    Application.get_env(:trpg_master, :ai_model, "claude-sonnet-4-6")
+  end
+
+  @doc "프로바이더 이름을 한국어로 반환"
+  def provider_label(:anthropic), do: "Anthropic"
+  def provider_label(:openai), do: "OpenAI"
+  def provider_label(:gemini), do: "Google Gemini"
+  def provider_label(_), do: "Unknown"
+end

--- a/lib/trpg_master/ai/providers/anthropic.ex
+++ b/lib/trpg_master/ai/providers/anthropic.ex
@@ -1,0 +1,321 @@
+defmodule TrpgMaster.AI.Providers.Anthropic do
+  @moduledoc """
+  Anthropic Claude API 프로바이더.
+  tool use 루프, 재시도, 프롬프트 캐싱을 포함한다.
+  """
+
+  alias TrpgMaster.AI.RateLimiter
+  require Logger
+
+  @api_url "https://api.anthropic.com/v1/messages"
+  @max_tool_iterations 5
+  @timeout 120_000
+
+  @doc """
+  Claude API에 메시지를 보내고 응답을 받는다.
+  tool use가 발생하면 도구를 실행하고 자동으로 재호출한다.
+  """
+  def chat(system_prompt, messages, tools \\ [], opts \\ []) do
+    api_key = Application.get_env(:trpg_master, :anthropic_api_key)
+
+    if is_nil(api_key) || api_key == "" do
+      {:error, :no_api_key}
+    else
+      selected_model = Keyword.get(opts, :model, default_model())
+      max_tokens = Keyword.get(opts, :max_tokens, 4096)
+
+      system_blocks = [
+        %{type: "text", text: system_prompt, cache_control: %{type: "ephemeral"}}
+      ]
+
+      cached_tools = add_cache_control_to_tools(tools)
+
+      body = %{
+        model: selected_model,
+        max_tokens: max_tokens,
+        system: system_blocks,
+        messages: messages,
+        tools: cached_tools
+      }
+
+      do_chat_with_retry(api_key, body, 0)
+    end
+  end
+
+  # ── 재시도 래퍼 ─────────────────────────────────────────────────────────────
+
+  defp do_chat_with_retry(api_key, body, retry_count) do
+    case do_chat_loop(api_key, body, [], @max_tool_iterations, %{
+           input_tokens: 0,
+           output_tokens: 0
+         }) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, reason} ->
+        handle_api_error(api_key, body, reason, retry_count)
+    end
+  end
+
+  defp handle_api_error(api_key, body, {:api_error, 400, _error_body}, retry_count)
+       when retry_count < 2 do
+    Logger.warning("API 400 오류 — 히스토리 트리밍 후 재시도 (#{retry_count + 1}/2)")
+    trimmed_body = aggressive_trim_history(body)
+    do_chat_with_retry(api_key, trimmed_body, retry_count + 1)
+  end
+
+  defp handle_api_error(api_key, body, {:api_error, 429, _error_body}, retry_count)
+       when retry_count < 3 do
+    wait_ms = 2000 * (retry_count + 1)
+    Logger.warning("Rate limit — #{wait_ms}ms 대기 후 재시도 (#{retry_count + 1}/3)")
+    Process.sleep(wait_ms)
+    do_chat_with_retry(api_key, body, retry_count + 1)
+  end
+
+  defp handle_api_error(api_key, body, {:api_error, status, _error_body}, retry_count)
+       when status in [500, 529] and retry_count < 2 do
+    Logger.warning("서버 에러 #{status} — 3초 대기 후 재시도 (#{retry_count + 1}/2)")
+    Process.sleep(3000)
+    do_chat_with_retry(api_key, body, retry_count + 1)
+  end
+
+  defp handle_api_error(_api_key, _body, {:api_error, 401, _}, _retry_count) do
+    {:error, :invalid_api_key}
+  end
+
+  defp handle_api_error(_api_key, _body, reason, _retry_count) do
+    {:error, reason}
+  end
+
+  defp add_cache_control_to_tools([]), do: []
+
+  defp add_cache_control_to_tools(tools) when is_list(tools) do
+    {last, rest} = List.pop_at(tools, -1)
+
+    if Map.has_key?(last, :cache_control) || Map.has_key?(last, "cache_control") do
+      tools
+    else
+      rest ++ [Map.put(last, :cache_control, %{type: "ephemeral"})]
+    end
+  end
+
+  defp aggressive_trim_history(body) do
+    messages = body.messages
+    take_count = min(max(div(length(messages), 2), 2), length(messages))
+    trimmed = Enum.take(messages, -take_count)
+
+    trimmed =
+      case trimmed do
+        [%{role: "assistant"} | rest] -> rest
+        other -> other
+      end
+
+    Logger.info("공격적 트리밍: #{length(messages)}개 → #{length(trimmed)}개")
+    %{body | messages: trimmed}
+  end
+
+  # ── Chat loop ───────────────────────────────────────────────────────────────
+
+  defp do_chat_loop(_api_key, _body, _tool_results, 0, _usage) do
+    Logger.warning("Tool use 최대 반복 횟수 초과")
+    {:error, :max_tool_iterations}
+  end
+
+  defp do_chat_loop(api_key, body, tool_results, iterations_left, usage) do
+    case RateLimiter.check_and_wait() do
+      :ok ->
+        case call_api(api_key, body) do
+          {:ok, response} ->
+            input_tokens = get_in(response, ["usage", "input_tokens"]) || 0
+            output_tokens = get_in(response, ["usage", "output_tokens"]) || 0
+
+            RateLimiter.record_usage(input_tokens)
+
+            new_usage = %{
+              input_tokens: usage.input_tokens + input_tokens,
+              output_tokens: usage.output_tokens + output_tokens
+            }
+
+            cache_read = get_in(response, ["usage", "cache_read_input_tokens"]) || 0
+            cache_create = get_in(response, ["usage", "cache_creation_input_tokens"]) || 0
+
+            Logger.info(
+              "Claude API 호출 — 입력: #{input_tokens}토큰, 출력: #{output_tokens}토큰, 캐시읽기: #{cache_read}토큰, 캐시생성: #{cache_create}토큰"
+            )
+
+            handle_response(api_key, body, response, tool_results, iterations_left, new_usage)
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, :rate_limited} ->
+        {:error, :rate_limited}
+    end
+  end
+
+  defp handle_response(api_key, body, response, tool_results, iterations_left, usage) do
+    content = Map.get(response, "content", [])
+    stop_reason = Map.get(response, "stop_reason")
+
+    text_parts =
+      content
+      |> Enum.filter(&(&1["type"] == "text"))
+      |> Enum.map(& &1["text"])
+
+    tool_use_blocks =
+      content
+      |> Enum.filter(&(&1["type"] == "tool_use"))
+
+    if stop_reason == "tool_use" && length(tool_use_blocks) > 0 do
+      {new_tool_results, tool_result_blocks} = execute_tools(tool_use_blocks)
+
+      updated_messages =
+        body.messages ++
+          [
+            %{role: "assistant", content: content},
+            %{role: "user", content: tool_result_blocks}
+          ]
+
+      updated_body = %{body | messages: updated_messages}
+
+      do_chat_loop(
+        api_key,
+        updated_body,
+        tool_results ++ new_tool_results,
+        iterations_left - 1,
+        usage
+      )
+    else
+      final_text = Enum.join(text_parts, "\n")
+
+      {:ok,
+       %{
+         text: final_text,
+         tool_results: tool_results,
+         usage: usage
+       }}
+    end
+  end
+
+  defp execute_tools(tool_use_blocks) do
+    results =
+      Enum.map(tool_use_blocks, fn block ->
+        tool_name = block["name"]
+        tool_input = block["input"]
+        tool_use_id = block["id"]
+
+        Logger.info("도구 실행: #{tool_name} — #{inspect(tool_input)}")
+
+        case TrpgMaster.AI.Tools.execute(tool_name, tool_input) do
+          {:ok, result} ->
+            {%{tool: tool_name, input: tool_input, result: result},
+             %{
+               type: "tool_result",
+               tool_use_id: tool_use_id,
+               content: Jason.encode!(result)
+             }}
+
+          {:error, reason} ->
+            {%{tool: tool_name, input: tool_input, error: reason},
+             %{
+               type: "tool_result",
+               tool_use_id: tool_use_id,
+               is_error: true,
+               content: "오류: #{reason}"
+             }}
+        end
+      end)
+
+    {Enum.map(results, &elem(&1, 0)), Enum.map(results, &elem(&1, 1))}
+  end
+
+  # ── HTTP ────────────────────────────────────────────────────────────────────
+
+  defp call_api(api_key, body) do
+    :ssl.start()
+    :inets.start()
+
+    json_body = Jason.encode!(body)
+
+    headers = [
+      {~c"x-api-key", String.to_charlist(api_key)},
+      {~c"anthropic-version", ~c"2023-06-01"},
+      {~c"anthropic-beta", ~c"prompt-caching-2024-07-31"},
+      {~c"content-type", ~c"application/json"}
+    ]
+
+    ssl_opts = ssl_options()
+
+    http_opts = [
+      timeout: @timeout,
+      connect_timeout: 10_000,
+      ssl: ssl_opts
+    ]
+
+    request = {String.to_charlist(@api_url), headers, ~c"application/json", json_body}
+
+    case :httpc.request(:post, request, http_opts, []) do
+      {:ok, {{_, status, _}, _headers, resp_body}} when status in 200..299 ->
+        case Jason.decode(:erlang.list_to_binary(resp_body)) do
+          {:ok, parsed} -> {:ok, parsed}
+          {:error, reason} -> {:error, {:json_parse_error, reason}}
+        end
+
+      {:ok, {{_, status, _}, _headers, resp_body}} ->
+        body_str = :erlang.list_to_binary(resp_body)
+        Logger.error("Claude API 오류 #{status}: #{body_str}")
+
+        error_body =
+          case Jason.decode(body_str) do
+            {:ok, parsed} -> parsed
+            _ -> %{"raw" => String.slice(body_str, 0, 300)}
+          end
+
+        {:error, {:api_error, status, error_body}}
+
+      {:error, {:failed_connect, _}} ->
+        {:error, :connection_failed}
+
+      {:error, :timeout} ->
+        {:error, :timeout}
+
+      {:error, reason} ->
+        Logger.error("HTTP 요청 실패: #{inspect(reason)}")
+        {:error, {:http_error, reason}}
+    end
+  end
+
+  defp ssl_options do
+    ca_cert_file = System.get_env("SSL_CERT_FILE") || find_cacert_file()
+
+    if File.exists?(ca_cert_file) do
+      [
+        verify: :verify_peer,
+        cacertfile: String.to_charlist(ca_cert_file),
+        depth: 10,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    else
+      [verify: :verify_none]
+    end
+  end
+
+  defp find_cacert_file do
+    paths = [
+      "/etc/ssl/certs/ca-certificates.crt",
+      "/etc/pki/tls/certs/ca-bundle.crt",
+      "/opt/homebrew/etc/openssl/cert.pem",
+      "/usr/local/etc/openssl/cert.pem",
+      "/etc/ssl/cert.pem"
+    ]
+
+    Enum.find(paths, List.first(paths), &File.exists?/1)
+  end
+
+  defp default_model do
+    Application.get_env(:trpg_master, :ai_model, "claude-sonnet-4-6")
+  end
+end

--- a/lib/trpg_master/ai/providers/gemini.ex
+++ b/lib/trpg_master/ai/providers/gemini.ex
@@ -1,0 +1,376 @@
+defmodule TrpgMaster.AI.Providers.Gemini do
+  @moduledoc """
+  Google Gemini API 프로바이더.
+  function calling(tool use) 루프와 재시도를 포함한다.
+  """
+
+  require Logger
+
+  @base_url "https://generativelanguage.googleapis.com/v1beta/models"
+  @max_tool_iterations 5
+  @timeout 120_000
+
+  @doc """
+  Gemini API에 메시지를 보내고 응답을 받는다.
+  functionCall이 발생하면 도구를 실행하고 자동으로 재호출한다.
+  """
+  def chat(system_prompt, messages, tools \\ [], opts \\ []) do
+    api_key = Application.get_env(:trpg_master, :google_api_key)
+
+    if is_nil(api_key) || api_key == "" do
+      {:error, :no_api_key}
+    else
+      model = Keyword.get(opts, :model, "gemini-2.5-flash")
+      max_tokens = Keyword.get(opts, :max_tokens, 4096)
+
+      gemini_contents = convert_messages(messages)
+      gemini_tools = convert_tools(tools)
+
+      body =
+        %{
+          system_instruction: %{parts: [%{text: system_prompt}]},
+          contents: gemini_contents,
+          generation_config: %{max_output_tokens: max_tokens}
+        }
+        |> maybe_add_tools(gemini_tools)
+
+      do_chat_with_retry(api_key, model, body, [], 0)
+    end
+  end
+
+  # ── 메시지 변환 ──────────────────────────────────────────────────────────────
+
+  # Claude/OpenAI 형식의 메시지를 Gemini contents 형식으로 변환
+  defp convert_messages(messages) do
+    Enum.flat_map(messages, fn msg ->
+      role = msg["role"] || msg[:role]
+      content = msg["content"] || msg[:content]
+
+      gemini_role = if role == "assistant", do: "model", else: "user"
+
+      case content do
+        text when is_binary(text) ->
+          [%{role: gemini_role, parts: [%{text: text}]}]
+
+        # tool_result 블록 목록 (user 역할)
+        parts when is_list(parts) ->
+          gemini_parts =
+            Enum.map(parts, fn part ->
+              type = part[:type] || part["type"]
+
+              cond do
+                type == "tool_result" ->
+                  %{
+                    function_response: %{
+                      name: part[:tool_use_id] || part["tool_use_id"] || "unknown",
+                      response: %{
+                        content: part[:content] || part["content"] || ""
+                      }
+                    }
+                  }
+
+                type == "tool_use" ->
+                  %{
+                    function_call: %{
+                      name: part[:name] || part["name"],
+                      args: part[:input] || part["input"] || %{}
+                    }
+                  }
+
+                true ->
+                  text_content = part[:text] || part["text"] || ""
+                  %{text: text_content}
+              end
+            end)
+            |> Enum.reject(&(&1 == %{text: ""}))
+
+          if gemini_parts == [] do
+            []
+          else
+            [%{role: gemini_role, parts: gemini_parts}]
+          end
+
+        _ ->
+          []
+      end
+    end)
+  end
+
+  # ── 도구 변환 ────────────────────────────────────────────────────────────────
+
+  defp convert_tools([]), do: []
+
+  defp convert_tools(tools) do
+    function_declarations =
+      Enum.map(tools, fn tool ->
+        name = tool[:name] || tool["name"]
+        description = tool[:description] || tool["description"]
+        input_schema = tool[:input_schema] || tool["input_schema"] || %{}
+
+        # Gemini는 additionalProperties를 지원하지 않으므로 제거
+        parameters = Map.drop(input_schema, ["additionalProperties", :additionalProperties])
+
+        %{
+          name: name,
+          description: description,
+          parameters: parameters
+        }
+      end)
+
+    [%{function_declarations: function_declarations}]
+  end
+
+  defp maybe_add_tools(body, []), do: body
+  defp maybe_add_tools(body, tools), do: Map.put(body, :tools, tools)
+
+  # ── 재시도 ───────────────────────────────────────────────────────────────────
+
+  defp do_chat_with_retry(api_key, model, body, tool_results, retry_count) do
+    case do_chat_loop(api_key, model, body, tool_results, @max_tool_iterations, %{
+           input_tokens: 0,
+           output_tokens: 0
+         }) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, reason} ->
+        handle_api_error(api_key, model, body, tool_results, reason, retry_count)
+    end
+  end
+
+  defp handle_api_error(api_key, model, body, tool_results, {:api_error, 429, _}, retry_count)
+       when retry_count < 3 do
+    wait_ms = 2000 * (retry_count + 1)
+    Logger.warning("Gemini Rate limit — #{wait_ms}ms 대기 후 재시도 (#{retry_count + 1}/3)")
+    Process.sleep(wait_ms)
+    do_chat_with_retry(api_key, model, body, tool_results, retry_count + 1)
+  end
+
+  defp handle_api_error(api_key, model, body, tool_results, {:api_error, status, _}, retry_count)
+       when status in [500, 503] and retry_count < 2 do
+    Logger.warning("Gemini 서버 에러 #{status} — 3초 대기 후 재시도 (#{retry_count + 1}/2)")
+    Process.sleep(3000)
+    do_chat_with_retry(api_key, model, body, tool_results, retry_count + 1)
+  end
+
+  defp handle_api_error(_api_key, _model, _body, _tool_results, {:api_error, 401, _}, _) do
+    {:error, :invalid_api_key}
+  end
+
+  defp handle_api_error(_api_key, _model, _body, _tool_results, reason, _) do
+    {:error, reason}
+  end
+
+  # ── Chat loop ───────────────────────────────────────────────────────────────
+
+  defp do_chat_loop(_api_key, _model, _body, _tool_results, 0, _usage) do
+    Logger.warning("Gemini Tool use 최대 반복 횟수 초과")
+    {:error, :max_tool_iterations}
+  end
+
+  defp do_chat_loop(api_key, model, body, tool_results, iterations_left, usage) do
+    case call_api(api_key, model, body) do
+      {:ok, response} ->
+        input_tokens =
+          get_in(response, ["usageMetadata", "promptTokenCount"]) || 0
+
+        output_tokens =
+          get_in(response, ["usageMetadata", "candidatesTokenCount"]) || 0
+
+        new_usage = %{
+          input_tokens: usage.input_tokens + input_tokens,
+          output_tokens: usage.output_tokens + output_tokens
+        }
+
+        Logger.info(
+          "Gemini API 호출 — 입력: #{input_tokens}토큰, 출력: #{output_tokens}토큰"
+        )
+
+        handle_response(api_key, model, body, response, tool_results, iterations_left, new_usage)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp handle_response(api_key, model, body, response, tool_results, iterations_left, usage) do
+    candidate = get_in(response, ["candidates", Access.at(0)]) || %{}
+    parts = get_in(candidate, ["content", "parts"]) || []
+    finish_reason = candidate["finishReason"]
+
+    function_calls = Enum.filter(parts, &Map.has_key?(&1, "functionCall"))
+    text_parts = Enum.filter(parts, &Map.has_key?(&1, "text"))
+
+    if finish_reason == "STOP" && function_calls == [] do
+      text =
+        text_parts
+        |> Enum.map(& &1["text"])
+        |> Enum.join("\n")
+
+      {:ok,
+       %{
+         text: text,
+         tool_results: tool_results,
+         usage: usage
+       }}
+    else
+      if function_calls != [] do
+        {new_tool_results, function_responses} = execute_tools(function_calls)
+
+        # 현재 모델 응답과 함수 결과를 contents에 추가
+        model_turn = %{
+          role: "model",
+          parts: Enum.map(function_calls, fn fc ->
+            %{function_call: fc["functionCall"]}
+          end)
+        }
+
+        user_turn = %{
+          role: "user",
+          parts: function_responses
+        }
+
+        updated_contents = body.contents ++ [model_turn, user_turn]
+        updated_body = %{body | contents: updated_contents}
+
+        do_chat_loop(
+          api_key,
+          model,
+          updated_body,
+          tool_results ++ new_tool_results,
+          iterations_left - 1,
+          usage
+        )
+      else
+        # 텍스트만 있는 경우
+        text =
+          text_parts
+          |> Enum.map(& &1["text"])
+          |> Enum.join("\n")
+
+        {:ok,
+         %{
+           text: text,
+           tool_results: tool_results,
+           usage: usage
+         }}
+      end
+    end
+  end
+
+  defp execute_tools(function_calls) do
+    results =
+      Enum.map(function_calls, fn fc ->
+        fc_data = fc["functionCall"] || fc
+        tool_name = fc_data["name"]
+        tool_input = fc_data["args"] || %{}
+
+        Logger.info("Gemini 도구 실행: #{tool_name} — #{inspect(tool_input)}")
+
+        case TrpgMaster.AI.Tools.execute(tool_name, tool_input) do
+          {:ok, result} ->
+            {%{tool: tool_name, input: tool_input, result: result},
+             %{
+               function_response: %{
+                 name: tool_name,
+                 response: %{content: Jason.encode!(result)}
+               }
+             }}
+
+          {:error, reason} ->
+            {%{tool: tool_name, input: tool_input, error: reason},
+             %{
+               function_response: %{
+                 name: tool_name,
+                 response: %{error: "오류: #{reason}"}
+               }
+             }}
+        end
+      end)
+
+    {Enum.map(results, &elem(&1, 0)), Enum.map(results, &elem(&1, 1))}
+  end
+
+  # ── HTTP ────────────────────────────────────────────────────────────────────
+
+  defp call_api(api_key, model, body) do
+    :ssl.start()
+    :inets.start()
+
+    json_body = Jason.encode!(body)
+    url = "#{@base_url}/#{model}:generateContent?key=#{api_key}"
+
+    headers = [
+      {~c"content-type", ~c"application/json"}
+    ]
+
+    ssl_opts = ssl_options()
+
+    http_opts = [
+      timeout: @timeout,
+      connect_timeout: 10_000,
+      ssl: ssl_opts
+    ]
+
+    request = {String.to_charlist(url), headers, ~c"application/json", json_body}
+
+    case :httpc.request(:post, request, http_opts, []) do
+      {:ok, {{_, status, _}, _headers, resp_body}} when status in 200..299 ->
+        case Jason.decode(:erlang.list_to_binary(resp_body)) do
+          {:ok, parsed} -> {:ok, parsed}
+          {:error, reason} -> {:error, {:json_parse_error, reason}}
+        end
+
+      {:ok, {{_, status, _}, _headers, resp_body}} ->
+        body_str = :erlang.list_to_binary(resp_body)
+        Logger.error("Gemini API 오류 #{status}: #{body_str}")
+
+        error_body =
+          case Jason.decode(body_str) do
+            {:ok, parsed} -> parsed
+            _ -> %{"raw" => String.slice(body_str, 0, 300)}
+          end
+
+        {:error, {:api_error, status, error_body}}
+
+      {:error, {:failed_connect, _}} ->
+        {:error, :connection_failed}
+
+      {:error, :timeout} ->
+        {:error, :timeout}
+
+      {:error, reason} ->
+        Logger.error("Gemini HTTP 요청 실패: #{inspect(reason)}")
+        {:error, {:http_error, reason}}
+    end
+  end
+
+  defp ssl_options do
+    ca_cert_file = System.get_env("SSL_CERT_FILE") || find_cacert_file()
+
+    if File.exists?(ca_cert_file) do
+      [
+        verify: :verify_peer,
+        cacertfile: String.to_charlist(ca_cert_file),
+        depth: 10,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    else
+      [verify: :verify_none]
+    end
+  end
+
+  defp find_cacert_file do
+    paths = [
+      "/etc/ssl/certs/ca-certificates.crt",
+      "/etc/pki/tls/certs/ca-bundle.crt",
+      "/opt/homebrew/etc/openssl/cert.pem",
+      "/usr/local/etc/openssl/cert.pem",
+      "/etc/ssl/cert.pem"
+    ]
+
+    Enum.find(paths, List.first(paths), &File.exists?/1)
+  end
+end

--- a/lib/trpg_master/ai/providers/openai.ex
+++ b/lib/trpg_master/ai/providers/openai.ex
@@ -1,0 +1,355 @@
+defmodule TrpgMaster.AI.Providers.OpenAI do
+  @moduledoc """
+  OpenAI Chat Completions API 프로바이더.
+  function calling(tool use) 루프와 재시도를 포함한다.
+  """
+
+  require Logger
+
+  @api_url "https://api.openai.com/v1/chat/completions"
+  @max_tool_iterations 5
+  @timeout 120_000
+
+  @doc """
+  OpenAI API에 메시지를 보내고 응답을 받는다.
+  tool_calls가 발생하면 도구를 실행하고 자동으로 재호출한다.
+  """
+  def chat(system_prompt, messages, tools \\ [], opts \\ []) do
+    api_key = Application.get_env(:trpg_master, :openai_api_key)
+
+    if is_nil(api_key) || api_key == "" do
+      {:error, :no_api_key}
+    else
+      model = Keyword.get(opts, :model, "gpt-4.1")
+      max_tokens = Keyword.get(opts, :max_tokens, 4096)
+
+      openai_messages = convert_messages(system_prompt, messages)
+      openai_tools = convert_tools(tools)
+
+      body =
+        %{
+          model: model,
+          max_tokens: max_tokens,
+          messages: openai_messages
+        }
+        |> maybe_add_tools(openai_tools)
+
+      do_chat_with_retry(api_key, body, [], 0)
+    end
+  end
+
+  # ── 메시지 변환 ──────────────────────────────────────────────────────────────
+
+  # Claude 형식의 메시지를 OpenAI 형식으로 변환
+  # system_prompt는 system 메시지로 앞에 추가
+  defp convert_messages(system_prompt, messages) do
+    system_msg = %{role: "system", content: system_prompt}
+
+    user_messages =
+      Enum.flat_map(messages, fn msg ->
+        role = msg["role"] || msg[:role]
+        content = msg["content"] || msg[:content]
+
+        case {role, content} do
+          {"user", content} when is_binary(content) ->
+            [%{role: "user", content: content}]
+
+          {"assistant", content} when is_binary(content) ->
+            [%{role: "assistant", content: content}]
+
+          # tool_result 블록을 포함한 user 메시지 (tool 호출 결과)
+          {"user", content} when is_list(content) ->
+            tool_results =
+              Enum.map(content, fn block ->
+                %{
+                  role: "tool",
+                  tool_call_id: block[:tool_use_id] || block["tool_use_id"],
+                  content: block[:content] || block["content"] || ""
+                }
+              end)
+
+            tool_results
+
+          # assistant 메시지에 tool_use 블록 포함 (Claude 형식 → OpenAI 변환)
+          {"assistant", content} when is_list(content) ->
+            text_parts = Enum.filter(content, &((&1["type"] || &1[:type]) == "text"))
+            tool_use_parts = Enum.filter(content, &((&1["type"] || &1[:type]) == "tool_use"))
+
+            text =
+              text_parts
+              |> Enum.map(&(&1["text"] || &1[:text] || ""))
+              |> Enum.join("\n")
+
+            tool_calls =
+              Enum.map(tool_use_parts, fn tu ->
+                %{
+                  id: tu["id"] || tu[:id],
+                  type: "function",
+                  function: %{
+                    name: tu["name"] || tu[:name],
+                    arguments: Jason.encode!(tu["input"] || tu[:input] || %{})
+                  }
+                }
+              end)
+
+            msg = %{role: "assistant"}
+            msg = if text != "", do: Map.put(msg, :content, text), else: msg
+
+            msg =
+              if tool_calls != [],
+                do: Map.put(msg, :tool_calls, tool_calls),
+                else: msg
+
+            [msg]
+
+          _ ->
+            []
+        end
+      end)
+
+    [system_msg | user_messages]
+  end
+
+  # ── 도구 변환 ────────────────────────────────────────────────────────────────
+
+  # Claude tool 정의 → OpenAI function 형식 변환
+  defp convert_tools([]), do: []
+
+  defp convert_tools(tools) do
+    Enum.map(tools, fn tool ->
+      name = tool[:name] || tool["name"]
+      description = tool[:description] || tool["description"]
+      input_schema = tool[:input_schema] || tool["input_schema"] || %{}
+
+      %{
+        type: "function",
+        function: %{
+          name: name,
+          description: description,
+          parameters: input_schema
+        }
+      }
+    end)
+  end
+
+  defp maybe_add_tools(body, []), do: body
+  defp maybe_add_tools(body, tools), do: Map.put(body, :tools, tools)
+
+  # ── 재시도 ───────────────────────────────────────────────────────────────────
+
+  defp do_chat_with_retry(api_key, body, tool_results, retry_count) do
+    case do_chat_loop(api_key, body, tool_results, @max_tool_iterations, %{
+           input_tokens: 0,
+           output_tokens: 0
+         }) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, reason} ->
+        handle_api_error(api_key, body, tool_results, reason, retry_count)
+    end
+  end
+
+  defp handle_api_error(api_key, body, tool_results, {:api_error, 429, _}, retry_count)
+       when retry_count < 3 do
+    wait_ms = 2000 * (retry_count + 1)
+    Logger.warning("OpenAI Rate limit — #{wait_ms}ms 대기 후 재시도 (#{retry_count + 1}/3)")
+    Process.sleep(wait_ms)
+    do_chat_with_retry(api_key, body, tool_results, retry_count + 1)
+  end
+
+  defp handle_api_error(api_key, body, tool_results, {:api_error, status, _}, retry_count)
+       when status in [500, 503] and retry_count < 2 do
+    Logger.warning("OpenAI 서버 에러 #{status} — 3초 대기 후 재시도 (#{retry_count + 1}/2)")
+    Process.sleep(3000)
+    do_chat_with_retry(api_key, body, tool_results, retry_count + 1)
+  end
+
+  defp handle_api_error(_api_key, _body, _tool_results, {:api_error, 401, _}, _retry_count) do
+    {:error, :invalid_api_key}
+  end
+
+  defp handle_api_error(_api_key, _body, _tool_results, reason, _retry_count) do
+    {:error, reason}
+  end
+
+  # ── Chat loop ───────────────────────────────────────────────────────────────
+
+  defp do_chat_loop(_api_key, _body, _tool_results, 0, _usage) do
+    Logger.warning("OpenAI Tool use 최대 반복 횟수 초과")
+    {:error, :max_tool_iterations}
+  end
+
+  defp do_chat_loop(api_key, body, tool_results, iterations_left, usage) do
+    case call_api(api_key, body) do
+      {:ok, response} ->
+        input_tokens = get_in(response, ["usage", "prompt_tokens"]) || 0
+        output_tokens = get_in(response, ["usage", "completion_tokens"]) || 0
+
+        new_usage = %{
+          input_tokens: usage.input_tokens + input_tokens,
+          output_tokens: usage.output_tokens + output_tokens
+        }
+
+        Logger.info(
+          "OpenAI API 호출 — 입력: #{input_tokens}토큰, 출력: #{output_tokens}토큰"
+        )
+
+        handle_response(api_key, body, response, tool_results, iterations_left, new_usage)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp handle_response(api_key, body, response, tool_results, iterations_left, usage) do
+    choice = get_in(response, ["choices", Access.at(0)]) || %{}
+    message = choice["message"] || %{}
+    finish_reason = choice["finish_reason"]
+    tool_calls = message["tool_calls"] || []
+
+    if finish_reason == "tool_calls" && length(tool_calls) > 0 do
+      {new_tool_results, tool_result_messages} = execute_tools(tool_calls)
+
+      # 현재 assistant 메시지를 히스토리에 추가
+      current_messages = body.messages ++ [message | tool_result_messages]
+      updated_body = %{body | messages: current_messages}
+
+      do_chat_loop(
+        api_key,
+        updated_body,
+        tool_results ++ new_tool_results,
+        iterations_left - 1,
+        usage
+      )
+    else
+      text = message["content"] || ""
+
+      {:ok,
+       %{
+         text: text,
+         tool_results: tool_results,
+         usage: usage
+       }}
+    end
+  end
+
+  defp execute_tools(tool_calls) do
+    results =
+      Enum.map(tool_calls, fn tc ->
+        tool_use_id = tc["id"]
+        tool_name = get_in(tc, ["function", "name"])
+
+        tool_input =
+          case Jason.decode(get_in(tc, ["function", "arguments"]) || "{}") do
+            {:ok, parsed} -> parsed
+            _ -> %{}
+          end
+
+        Logger.info("OpenAI 도구 실행: #{tool_name} — #{inspect(tool_input)}")
+
+        case TrpgMaster.AI.Tools.execute(tool_name, tool_input) do
+          {:ok, result} ->
+            {%{tool: tool_name, input: tool_input, result: result},
+             %{
+               role: "tool",
+               tool_call_id: tool_use_id,
+               content: Jason.encode!(result)
+             }}
+
+          {:error, reason} ->
+            {%{tool: tool_name, input: tool_input, error: reason},
+             %{
+               role: "tool",
+               tool_call_id: tool_use_id,
+               content: "오류: #{reason}"
+             }}
+        end
+      end)
+
+    {Enum.map(results, &elem(&1, 0)), Enum.map(results, &elem(&1, 1))}
+  end
+
+  # ── HTTP ────────────────────────────────────────────────────────────────────
+
+  defp call_api(api_key, body) do
+    :ssl.start()
+    :inets.start()
+
+    json_body = Jason.encode!(body)
+
+    headers = [
+      {~c"authorization", String.to_charlist("Bearer #{api_key}")},
+      {~c"content-type", ~c"application/json"}
+    ]
+
+    ssl_opts = ssl_options()
+
+    http_opts = [
+      timeout: @timeout,
+      connect_timeout: 10_000,
+      ssl: ssl_opts
+    ]
+
+    request = {String.to_charlist(@api_url), headers, ~c"application/json", json_body}
+
+    case :httpc.request(:post, request, http_opts, []) do
+      {:ok, {{_, status, _}, _headers, resp_body}} when status in 200..299 ->
+        case Jason.decode(:erlang.list_to_binary(resp_body)) do
+          {:ok, parsed} -> {:ok, parsed}
+          {:error, reason} -> {:error, {:json_parse_error, reason}}
+        end
+
+      {:ok, {{_, status, _}, _headers, resp_body}} ->
+        body_str = :erlang.list_to_binary(resp_body)
+        Logger.error("OpenAI API 오류 #{status}: #{body_str}")
+
+        error_body =
+          case Jason.decode(body_str) do
+            {:ok, parsed} -> parsed
+            _ -> %{"raw" => String.slice(body_str, 0, 300)}
+          end
+
+        {:error, {:api_error, status, error_body}}
+
+      {:error, {:failed_connect, _}} ->
+        {:error, :connection_failed}
+
+      {:error, :timeout} ->
+        {:error, :timeout}
+
+      {:error, reason} ->
+        Logger.error("OpenAI HTTP 요청 실패: #{inspect(reason)}")
+        {:error, {:http_error, reason}}
+    end
+  end
+
+  defp ssl_options do
+    ca_cert_file = System.get_env("SSL_CERT_FILE") || find_cacert_file()
+
+    if File.exists?(ca_cert_file) do
+      [
+        verify: :verify_peer,
+        cacertfile: String.to_charlist(ca_cert_file),
+        depth: 10,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    else
+      [verify: :verify_none]
+    end
+  end
+
+  defp find_cacert_file do
+    paths = [
+      "/etc/ssl/certs/ca-certificates.crt",
+      "/etc/pki/tls/certs/ca-bundle.crt",
+      "/opt/homebrew/etc/openssl/cert.pem",
+      "/usr/local/etc/openssl/cert.pem",
+      "/etc/ssl/cert.pem"
+    ]
+
+    Enum.find(paths, List.first(paths), &File.exists?/1)
+  end
+end

--- a/lib/trpg_master/campaign/manager.ex
+++ b/lib/trpg_master/campaign/manager.ex
@@ -11,12 +11,13 @@ defmodule TrpgMaster.Campaign.Manager do
   @doc """
   새 캠페인을 생성하고 서버를 시작한다.
   """
-  def create_campaign(name) do
+  def create_campaign(name, ai_model \\ nil) do
     id = generate_id()
 
     state = %State{
       id: id,
-      name: name
+      name: name,
+      ai_model: ai_model
     }
 
     case start_server(state) do

--- a/lib/trpg_master/campaign/server.ex
+++ b/lib/trpg_master/campaign/server.ex
@@ -8,7 +8,7 @@ defmodule TrpgMaster.Campaign.Server do
   use GenServer
 
   alias TrpgMaster.Campaign.{State, Persistence}
-  alias TrpgMaster.AI.{Client, PromptBuilder, Tools}
+  alias TrpgMaster.AI.{Client, Models, PromptBuilder, Tools}
 
   require Logger
 
@@ -30,6 +30,10 @@ defmodule TrpgMaster.Campaign.Server do
 
   def set_mode(campaign_id, mode) when mode in [:adventure, :debug] do
     GenServer.call(via(campaign_id), {:set_mode, mode})
+  end
+
+  def set_model(campaign_id, model_id) do
+    GenServer.call(via(campaign_id), {:set_model, model_id})
   end
 
   def end_session(campaign_id) do
@@ -73,6 +77,14 @@ defmodule TrpgMaster.Campaign.Server do
   end
 
   @impl true
+  def handle_call({:set_model, model_id}, _from, state) do
+    new_state = %{state | ai_model: model_id}
+    Persistence.save_async(new_state)
+    Logger.info("AI 모델 변경 [#{state.id}]: #{state.ai_model} → #{model_id}")
+    {:reply, :ok, new_state}
+  end
+
+  @impl true
   def handle_call(:end_session, _from, state) do
     Logger.info("세션 종료 처리 시작 [#{state.id}] 턴 #{state.turn_count}")
 
@@ -110,9 +122,15 @@ defmodule TrpgMaster.Campaign.Server do
     # read_journal 도구가 현재 저널 데이터에 접근할 수 있도록 프로세스 딕셔너리에 저장
     Process.put(:journal_entries, state.journal_entries)
 
+    model_opts =
+      case state.ai_model do
+        nil -> []
+        model_id -> [model: model_id]
+      end
+
     result =
       try do
-        Client.chat(system_prompt, trimmed_history, tools)
+        Client.chat(system_prompt, trimmed_history, tools, model_opts)
       after
         Process.delete(:journal_entries)
       end
@@ -160,8 +178,8 @@ defmodule TrpgMaster.Campaign.Server do
   end
 
   defp generate_session_summary(state) do
-    # 비용 절약을 위해 Haiku 모델 사용
-    haiku_model = "claude-haiku-4-5-20251001"
+    # 현재 캠페인의 프로바이더와 동일한 저비용 모델 사용
+    haiku_model = summary_model_for(state.ai_model)
 
     summary_prompt = """
     당신은 D&D 세션 서기입니다. 아래 세션 정보를 바탕으로 간결한 세션 요약을 작성해주세요.
@@ -234,6 +252,17 @@ defmodule TrpgMaster.Campaign.Server do
       "- #{q["name"]}#{status}"
     end)
     |> Enum.join("\n")
+  end
+
+  # 현재 선택된 모델의 프로바이더에 맞는 요약 모델 반환
+  defp summary_model_for(nil), do: "claude-haiku-4-5-20251001"
+  defp summary_model_for(model_id) do
+    case Models.provider_for(model_id) do
+      :anthropic -> "claude-haiku-4-5-20251001"
+      :openai -> "gpt-4.1-mini"
+      :gemini -> "gemini-2.5-flash"
+      _ -> "claude-haiku-4-5-20251001"
+    end
   end
 
   # 도구 결과 리스트를 순회하며 캠페인 상태에 반영한다.

--- a/lib/trpg_master/campaign/state.ex
+++ b/lib/trpg_master/campaign/state.ex
@@ -15,7 +15,8 @@ defmodule TrpgMaster.Campaign.State do
     conversation_history: [],
     turn_count: 0,
     mode: :adventure,
-    journal_entries: []
+    journal_entries: [],
+    ai_model: nil
   ]
 
   @doc """
@@ -35,7 +36,8 @@ defmodule TrpgMaster.Campaign.State do
       "updated_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
       "character_names" => state.characters |> Enum.map(& &1["name"]) |> Enum.reject(&is_nil/1),
       "npc_names" => Map.keys(state.npcs),
-      "journal_count" => length(state.journal_entries)
+      "journal_count" => length(state.journal_entries),
+      "ai_model" => state.ai_model
     }
   end
 
@@ -52,7 +54,8 @@ defmodule TrpgMaster.Campaign.State do
       active_quests: summary["active_quests"] || [],
       turn_count: summary["turn_count"] || 0,
       mode: safe_atom(summary["mode"], :adventure),
-      combat_state: summary["combat_state"]
+      combat_state: summary["combat_state"],
+      ai_model: summary["ai_model"]
       # journal_entries는 Persistence.load에서 별도로 로드한다
     }
   end

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -4,7 +4,7 @@ defmodule TrpgMasterWeb.CampaignLive do
   import TrpgMasterWeb.GameComponents
 
   alias TrpgMaster.Campaign.{Manager, Server}
-  alias TrpgMaster.AI.Client
+  alias TrpgMaster.AI.{Client, Models}
 
   @impl true
   def mount(%{"id" => campaign_id}, _session, socket) do
@@ -12,6 +12,7 @@ defmodule TrpgMasterWeb.CampaignLive do
       {:ok, _id} ->
         state = Server.get_state(campaign_id)
         messages = build_display_messages(state.conversation_history)
+        current_model = state.ai_model || Models.default_model()
 
         {:ok,
          socket
@@ -29,7 +30,10 @@ defmodule TrpgMasterWeb.CampaignLive do
          |> assign(:combat_state, state.combat_state)
          |> assign(:mode, state.mode)
          |> assign(:processing, false)
-         |> assign(:ending_session, false)}
+         |> assign(:ending_session, false)
+         |> assign(:ai_model, current_model)
+         |> assign(:show_model_selector, false)
+         |> assign(:available_models, Models.list_with_status())}
 
       {:error, :not_found} ->
         {:ok,
@@ -99,6 +103,48 @@ defmodule TrpgMasterWeb.CampaignLive do
     {:noreply, assign(socket, :mode, new_mode)}
   end
 
+  # ── DM 선택 ─────────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("toggle_model_selector", _, socket) do
+    {:noreply, assign(socket, :show_model_selector, !socket.assigns.show_model_selector)}
+  end
+
+  @impl true
+  def handle_event("select_model", %{"model" => model_id}, socket) do
+    campaign_id = socket.assigns.campaign_id
+
+    if Models.api_key_configured?(model_id) do
+      Server.set_model(campaign_id, model_id)
+      model_info = Models.find(model_id)
+      model_name = if model_info, do: model_info.name, else: model_id
+
+      notice_msg = %{type: :system, text: "🤖 DM이 #{model_name}(으)로 변경되었습니다."}
+      messages = socket.assigns.messages ++ [notice_msg]
+
+      {:noreply,
+       socket
+       |> assign(:ai_model, model_id)
+       |> assign(:show_model_selector, false)
+       |> assign(:messages, messages)}
+    else
+      model_info = Models.find(model_id)
+      env_var = if model_info, do: model_info.env, else: "API 키"
+
+      notice_msg = %{
+        type: :system,
+        text: "⚠️ #{env_var} 환경변수가 설정되지 않았습니다. 서버 관리자에게 문의하세요."
+      }
+
+      messages = socket.assigns.messages ++ [notice_msg]
+
+      {:noreply,
+       socket
+       |> assign(:show_model_selector, false)
+       |> assign(:messages, messages)}
+    end
+  end
+
   # ── 세션 종료 ────────────────────────────────────────────────────────────────
 
   @impl true
@@ -125,7 +171,6 @@ defmodule TrpgMasterWeb.CampaignLive do
           Enum.reduce(result.tool_results, socket.assigns.messages, fn tool_result, acc ->
             case tool_result do
               %{result: %{"formatted" => _} = dice_result} ->
-                # 모험 모드에서 hidden 주사위 결과 숨김
                 if socket.assigns.mode == :adventure && Map.get(tool_result.input || %{}, "hidden") do
                   acc
                 else
@@ -206,6 +251,9 @@ defmodule TrpgMasterWeb.CampaignLive do
         <div class="header-right">
           <span :if={@current_location} class="location-badge"><%= @current_location %></span>
           <span class="mode-badge"><%= phase_label(@phase) %></span>
+          <button phx-click="toggle_model_selector" class="dm-select-btn" title="DM 선택">
+            🤖 <%= model_short_name(@ai_model) %>
+          </button>
           <button phx-click="toggle_mode" class={"mode-toggle #{if @mode == :debug, do: "mode-debug", else: "mode-adventure"}"} title={if @mode == :adventure, do: "디버그 모드로 전환", else: "모험 모드로 전환"}>
             <%= if @mode == :adventure do %>🎭<% else %>🔧<% end %>
           </button>
@@ -214,6 +262,39 @@ defmodule TrpgMasterWeb.CampaignLive do
           </button>
         </div>
       </header>
+
+      <%= if @show_model_selector do %>
+        <div class="model-selector-overlay" phx-click="toggle_model_selector"></div>
+        <div class="model-selector-modal">
+          <div class="model-selector-header">
+            <h3>🤖 DM 선택</h3>
+            <button phx-click="toggle_model_selector" class="modal-close-btn">✕</button>
+          </div>
+          <div class="model-selector-list">
+            <%= for provider <- [:anthropic, :openai, :gemini] do %>
+              <div class="model-provider-group">
+                <div class="model-provider-label"><%= Models.provider_label(provider) %></div>
+                <%= for model <- Enum.filter(@available_models, &(&1.provider == provider)) do %>
+                  <button
+                    class={"model-option #{if model.id == @ai_model, do: "model-option-active", else: ""} #{if not model.available, do: "model-option-disabled", else: ""}"}
+                    phx-click="select_model"
+                    phx-value-model={model.id}
+                    title={unless model.available, do: "#{model.env} 환경변수가 설정되지 않았습니다.", else: ""}
+                  >
+                    <span class="model-option-name"><%= model.name %></span>
+                    <%= if model.id == @ai_model do %>
+                      <span class="model-option-badge model-badge-active">사용 중</span>
+                    <% end %>
+                    <%= unless model.available do %>
+                      <span class="model-option-badge model-badge-unavailable">API 키 미설정</span>
+                    <% end %>
+                  </button>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
 
       <div class="chat-area" id="chat-area" phx-hook="ScrollBottom">
         <%= if @messages == [] do %>
@@ -314,4 +395,11 @@ defmodule TrpgMasterWeb.CampaignLive do
   defp phase_label(:dialogue), do: "대화"
   defp phase_label(:rest), do: "휴식"
   defp phase_label(_), do: "모험"
+
+  defp model_short_name(model_id) do
+    case Models.find(model_id) do
+      nil -> model_id || "선택"
+      model -> model.name
+    end
+  end
 end

--- a/lib/trpg_master_web/live/lobby_live.ex
+++ b/lib/trpg_master_web/live/lobby_live.ex
@@ -2,6 +2,7 @@ defmodule TrpgMasterWeb.LobbyLive do
   use TrpgMasterWeb, :live_view
 
   alias TrpgMaster.Campaign.{Manager, Persistence}
+  alias TrpgMaster.AI.Models
 
   @impl true
   def mount(_params, _session, socket) do
@@ -11,17 +12,20 @@ defmodule TrpgMasterWeb.LobbyLive do
      socket
      |> assign(:campaigns, campaigns)
      |> assign(:new_name, "")
+     |> assign(:selected_model, Models.default_model())
+     |> assign(:available_models, Models.list_with_status())
      |> assign(:error, nil)}
   end
 
   @impl true
-  def handle_event("create_campaign", %{"name" => name}, socket) do
+  def handle_event("create_campaign", %{"name" => name} = params, socket) do
     name = String.trim(name)
+    model_id = Map.get(params, "model", Models.default_model())
 
     if name == "" do
       {:noreply, assign(socket, :error, "캠페인 이름을 입력하세요.")}
     else
-      case Manager.create_campaign(name) do
+      case Manager.create_campaign(name, model_id) do
         {:ok, id} ->
           {:noreply, push_navigate(socket, to: "/play/#{id}")}
 
@@ -51,14 +55,34 @@ defmodule TrpgMasterWeb.LobbyLive do
         <section class="new-campaign">
           <h2>새 캠페인 시작</h2>
           <form phx-submit="create_campaign" class="new-campaign-form">
-            <input
-              type="text"
-              name="name"
-              value={@new_name}
-              placeholder="캠페인 이름을 입력하세요"
-              autocomplete="off"
-            />
-            <button type="submit">시작</button>
+            <div class="new-campaign-form-row">
+              <input
+                type="text"
+                name="name"
+                value={@new_name}
+                placeholder="캠페인 이름을 입력하세요"
+                autocomplete="off"
+              />
+              <button type="submit">시작</button>
+            </div>
+            <div class="dm-select-group">
+              <label class="dm-select-label">🤖 DM 선택</label>
+              <select name="model" class="dm-model-select">
+                <%= for provider <- [:anthropic, :openai, :gemini] do %>
+                  <optgroup label={Models.provider_label(provider)}>
+                    <%= for model <- Enum.filter(@available_models, &(&1.provider == provider)) do %>
+                      <option
+                        value={model.id}
+                        selected={model.id == @selected_model}
+                        disabled={not model.available}
+                      >
+                        <%= model.name %><%= unless model.available, do: " (API 키 미설정)", else: "" %>
+                      </option>
+                    <% end %>
+                  </optgroup>
+                <% end %>
+              </select>
+            </div>
           </form>
           <%= if @error do %>
             <p class="lobby-error"><%= @error %></p>

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -471,6 +471,12 @@ html, body {
 
 .new-campaign-form {
   display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.new-campaign-form-row {
+  display: flex;
   gap: 0.5rem;
 }
 
@@ -802,6 +808,192 @@ html, body {
 
 .login-btn:hover {
   opacity: 0.9;
+}
+
+/* ── DM 선택 버튼 & 모달 ────────────────────────────────────────────── */
+
+.dm-select-btn {
+  padding: 0.3rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+  max-width: 130px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dm-select-btn:hover {
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border-color: var(--accent-gold);
+}
+
+.model-selector-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 200;
+}
+
+.model-selector-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 201;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  width: min(360px, 90vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.model-selector-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.model-selector-header h3 {
+  color: var(--accent-gold);
+  font-size: 1rem;
+}
+
+.modal-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  transition: all 0.2s;
+}
+
+.modal-close-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.model-selector-list {
+  padding: 0.75rem;
+}
+
+.model-provider-group {
+  margin-bottom: 0.75rem;
+}
+
+.model-provider-label {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.model-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: left;
+  gap: 0.5rem;
+}
+
+.model-option:hover {
+  background: var(--bg-input);
+  border-color: var(--border-color);
+}
+
+.model-option-active {
+  border-color: var(--accent-gold) !important;
+  background: rgba(212, 168, 71, 0.1) !important;
+}
+
+.model-option-disabled {
+  opacity: 0.5;
+}
+
+.model-option-disabled:hover {
+  background: transparent;
+  border-color: transparent;
+  cursor: default;
+}
+
+.model-option-name {
+  flex: 1;
+}
+
+.model-option-badge {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
+.model-badge-active {
+  background: rgba(212, 168, 71, 0.2);
+  color: var(--accent-gold);
+  border: 1px solid rgba(212, 168, 71, 0.4);
+}
+
+.model-badge-unavailable {
+  background: rgba(231, 76, 60, 0.15);
+  color: var(--accent-red);
+  border: 1px solid rgba(231, 76, 60, 0.3);
+}
+
+/* ── 로비 DM 선택 ──────────────────────────────────────────────────── */
+
+.dm-select-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.dm-select-label {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.dm-model-select {
+  flex: 1;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  outline: none;
+}
+
+.dm-model-select:focus {
+  border-color: var(--accent-gold);
+}
+
+.dm-model-select option:disabled {
+  color: var(--text-secondary);
+  font-style: italic;
 }
 
 /* ── 모바일 조정 ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
- AI.Models: 지원 모델 목록(Claude/GPT-4.1/Gemini 2.5) 및 API 키 가용성 관리
- AI.Client: 프로바이더 facade로 변환, 모델별 적합한 구현체로 dispatch
- AI.Providers.Anthropic: 기존 client.ex 로직 분리
- AI.Providers.OpenAI: GPT-4.1/4.1-mini function calling 구현
- AI.Providers.Gemini: Gemini 2.5 Pro/Flash generateContent API 구현
- Campaign.State: ai_model 필드 추가 (직렬화/역직렬화 포함)
- Campaign.Server: set_model/2 추가, player_action 시 캠페인 모델 사용
- Campaign.Manager: create_campaign에 ai_model 파라미터 추가
- LobbyLive: 새 캠페인 생성 시 DM 모델 선택 드롭다운 추가
- CampaignLive: 헤더에 DM 선택 버튼/모달 추가, API 키 미설정 알림
- config/runtime.exs: OPENAI_API_KEY, GOOGLE_API_KEY 환경변수 추가
- CSS: DM 선택 버튼/모달/모델 목록 스타일 추가

https://claude.ai/code/session_0114Wa45ezaUfxqP1iKX5TsL