### PR TITLE
feat: 채팅 히스토리 소설 포맷 뷰어 추가

### DIFF
--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -257,6 +257,9 @@ defmodule TrpgMasterWeb.CampaignLive do
           <button phx-click="toggle_mode" class={"mode-toggle #{if @mode == :debug, do: "mode-debug", else: "mode-adventure"}"} title={if @mode == :adventure, do: "디버그 모드로 전환", else: "모험 모드로 전환"}>
             <%= if @mode == :adventure do %>🎭<% else %>🔧<% end %>
           </button>
+          <a href={"/history/#{@campaign_id}"} class="history-btn" title="모험 기록 보기" target="_blank">
+            📖
+          </a>
           <button phx-click="end_session" class="end-session-btn" title="세션 종료" disabled={@loading}>
             📋
           </button>

--- a/lib/trpg_master_web/live/history_live.ex
+++ b/lib/trpg_master_web/live/history_live.ex
@@ -1,0 +1,98 @@
+defmodule TrpgMasterWeb.HistoryLive do
+  use TrpgMasterWeb, :live_view
+
+  import Phoenix.HTML, only: [raw: 1]
+
+  alias TrpgMaster.Campaign.Persistence
+
+  @impl true
+  def mount(%{"id" => campaign_id}, _session, socket) do
+    case Persistence.load(campaign_id) do
+      {:ok, state} ->
+        entries = build_novel_entries(state.conversation_history, state.characters)
+
+        {:ok,
+         socket
+         |> assign(:campaign_id, campaign_id)
+         |> assign(:campaign_name, state.name)
+         |> assign(:entries, entries)
+         |> assign(:character_name, extract_character_name(state.characters))}
+
+      {:error, :not_found} ->
+        {:ok,
+         socket
+         |> put_flash(:error, "캠페인을 찾을 수 없습니다.")
+         |> push_navigate(to: "/")}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="history-container">
+      <header class="history-header">
+        <div class="header-left">
+          <a href={"/play/#{@campaign_id}"} class="back-link">←</a>
+          <div class="history-title-group">
+            <h1><%= @campaign_name %></h1>
+            <span class="history-subtitle">모험 기록</span>
+          </div>
+        </div>
+      </header>
+
+      <div class="history-scroll">
+        <div class="novel-content">
+          <%= if @entries == [] do %>
+            <p class="novel-empty">아직 기록된 대화가 없습니다.</p>
+          <% end %>
+
+          <%= for {entry, idx} <- Enum.with_index(@entries) do %>
+            <%= case entry.type do %>
+              <% :dm -> %>
+                <div class="novel-dm" id={"entry-#{idx}"}>
+                  <%= raw(format_markdown(entry.text)) %>
+                </div>
+              <% :player -> %>
+                <div class="novel-player" id={"entry-#{idx}"}>
+                  <span class="novel-player-name"><%= @character_name %></span>
+                  <span class="novel-player-text"><%= entry.text %></span>
+                </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # ── Private helpers ──────────────────────────────────────────────────────────
+
+  defp build_novel_entries(conversation_history, _characters) do
+    conversation_history
+    |> Enum.reduce([], fn msg, acc ->
+      case msg do
+        %{"role" => "user", "content" => content} when is_binary(content) ->
+          acc ++ [%{type: :player, text: content}]
+
+        %{"role" => "assistant", "content" => content} when is_binary(content) ->
+          acc ++ [%{type: :dm, text: content}]
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp extract_character_name([%{"name" => name} | _]) when is_binary(name), do: name
+  defp extract_character_name(_), do: "플레이어"
+
+  defp format_markdown(text) when is_binary(text) do
+    case Earmark.as_html(text, %Earmark.Options{breaks: true}) do
+      {:ok, html, _warnings} -> html
+      {:error, _, _} ->
+        text |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+    end
+  end
+
+  defp format_markdown(_), do: ""
+end

--- a/lib/trpg_master_web/router.ex
+++ b/lib/trpg_master_web/router.ex
@@ -29,6 +29,7 @@ defmodule TrpgMasterWeb.Router do
 
     live "/", LobbyLive, :index
     live "/play/:id", CampaignLive, :play
+    live "/history/:id", HistoryLive, :history
   end
 
   # ── Auth Plug ──────────────────────────────────────────────────────────────

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -1014,3 +1014,204 @@ html, body {
     gap: 0.25rem;
   }
 }
+
+/* ── 히스토리 버튼 ───────────────────────────────────────────────────── */
+
+.history-btn {
+  padding: 0.3rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  line-height: 1;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.history-btn:hover {
+  background: var(--bg-input);
+  color: var(--text-primary);
+}
+
+/* ── 히스토리 (소설 포맷) 페이지 ────────────────────────────────────── */
+
+.history-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.history-title-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.history-title-group h1 {
+  font-size: 1.1rem;
+  color: var(--accent-gold);
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.history-subtitle {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.history-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem 1.5rem;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+
+.history-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.history-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.history-scroll::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 3px;
+}
+
+/* 소설 본문 영역 */
+.novel-content {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.novel-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  font-style: italic;
+  margin-top: 4rem;
+}
+
+/* DM 서술 — 소설 본문 스타일 */
+.novel-dm {
+  font-size: 1rem;
+  line-height: 1.85;
+  color: var(--text-primary);
+  font-family: Georgia, 'Nanum Myeongjo', serif;
+  letter-spacing: 0.01em;
+}
+
+.novel-dm p {
+  margin: 0 0 0.6em;
+  text-indent: 0;
+}
+
+.novel-dm p:first-child {
+  margin-top: 0;
+}
+
+.novel-dm strong {
+  color: var(--accent-gold);
+  font-weight: 700;
+}
+
+.novel-dm em {
+  color: #c8b8a2;
+  font-style: italic;
+}
+
+.novel-dm h1,
+.novel-dm h2,
+.novel-dm h3,
+.novel-dm h4 {
+  color: var(--accent-gold);
+  font-weight: 700;
+  margin: 0.8em 0 0.3em;
+  font-size: 1em;
+  letter-spacing: 0.05em;
+  font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.novel-dm ul {
+  margin: 0.4em 0;
+  padding-left: 1.4em;
+  list-style: disc;
+}
+
+.novel-dm li {
+  margin: 0.15em 0;
+}
+
+.novel-dm hr {
+  border: none;
+  border-top: 1px solid rgba(212, 168, 71, 0.25);
+  margin: 1em 0;
+}
+
+.novel-dm code {
+  background: rgba(255,255,255,0.07);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.88em;
+}
+
+/* 플레이어 행동 — 들여쓰기 이탤릭 */
+.novel-player {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.5rem 0.75rem;
+  border-left: 2px solid rgba(52, 152, 219, 0.4);
+  background: rgba(52, 152, 219, 0.05);
+  border-radius: 0 6px 6px 0;
+}
+
+.novel-player-name {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent-blue);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.novel-player-text {
+  font-size: 0.95rem;
+  color: #b0c4d8;
+  font-style: italic;
+  line-height: 1.6;
+}
+
+/* 모바일 */
+@media (max-width: 600px) {
+  .history-scroll {
+    padding: 1.25rem 1rem;
+  }
+
+  .novel-dm {
+    font-size: 0.95rem;
+  }
+}


### PR DESCRIPTION
- /history/:id 라우트에 HistoryLive LiveView 신규 생성
- 캠페인 헤더에 📖 히스토리 버튼 추가 (새 탭으로 열림)
- DM 서술은 소설 본문 스타일(Georgia serif), 플레이어 행동은 이탤릭 들여쓰기로 표시
- 채팅 기능 없이 읽기 전용 히스토리만 제공
- Persistence.load/1 로 직접 데이터 로드 (GenServer 불필요)

https://claude.ai/code/session_014DeWW9AbafehZWFPJaB7Ck