### PR TITLE
Remove location badge from mobile top bar header

### DIFF
--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -249,7 +249,6 @@ defmodule TrpgMasterWeb.CampaignLive do
           <h1><%= @campaign_name %></h1>
         </div>
         <div class="header-right">
-          <span :if={@current_location} class="location-badge"><%= @current_location %></span>
           <span class="mode-badge"><%= phase_label(@phase) %></span>
           <button phx-click="toggle_model_selector" class="dm-select-btn" title="DM 선택">
             🤖 <%= model_short_name(@ai_model) %>

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -601,14 +601,6 @@ html, body {
   color: var(--accent-gold);
 }
 
-.location-badge {
-  font-size: 0.75rem;
-  padding: 0.2rem 0.6rem;
-  border-radius: 12px;
-  background: rgba(46, 204, 113, 0.15);
-  color: var(--accent-green);
-  border: 1px solid rgba(46, 204, 113, 0.3);
-}
 
 /* Safe area for notched phones */
 @supports (padding-bottom: env(safe-area-inset-bottom)) {


### PR DESCRIPTION
Location is already shown in the bottom status bar, so the
location-badge in the header-right is redundant and takes up
limited space on mobile.

https://claude.ai/code/session_018arD5nTjEq33YxruLohZ7P