### PR TITLE
Add context summary to reduce token usage in long campaigns

### DIFF
--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -73,6 +73,21 @@ defmodule TrpgMaster.AI.PromptBuilder do
   end
 
   @doc """
+  요약 기반 메시지 구성. 전체 히스토리 대신 최신 요약 + 현재 메시지만 전달한다.
+  """
+  def build_messages_with_summary(current_message, nil) do
+    [%{"role" => "user", "content" => current_message}]
+  end
+
+  def build_messages_with_summary(current_message, context_summary) do
+    [
+      %{"role" => "user", "content" => "[이전 상황 요약]\n#{context_summary}"},
+      %{"role" => "assistant", "content" => "네, 이전 상황을 파악했습니다. 계속 진행하겠습니다."},
+      %{"role" => "user", "content" => current_message}
+    ]
+  end
+
+  @doc """
   하위 호환: trim_history/1은 build_messages/1로 대체됨.
   """
   def trim_history(history), do: build_messages(history)

--- a/lib/trpg_master/campaign/persistence.ex
+++ b/lib/trpg_master/campaign/persistence.ex
@@ -25,7 +25,8 @@ defmodule TrpgMaster.Campaign.Persistence do
          :ok <- save_characters(dir, state.characters),
          :ok <- save_npcs(dir, state.npcs),
          :ok <- write_json(Path.join(dir, "conversation_history.json"), state.conversation_history),
-         :ok <- write_json(Path.join(dir, "journal.json"), state.journal_entries) do
+         :ok <- write_json(Path.join(dir, "journal.json"), state.journal_entries),
+         :ok <- save_context_summary(dir, state.context_summary) do
       :ok
     else
       {:error, reason} ->
@@ -66,12 +67,15 @@ defmodule TrpgMaster.Campaign.Persistence do
            {:ok, npcs} <- load_npcs(dir),
            {:ok, history} <- load_conversation_history(dir),
            {:ok, journal} <- load_journal(dir) do
+        context_summary = load_context_summary(dir)
+
         state =
           State.from_summary(summary)
           |> Map.put(:characters, characters)
           |> Map.put(:npcs, npcs)
           |> Map.put(:conversation_history, history)
           |> Map.put(:journal_entries, journal)
+          |> Map.put(:context_summary, context_summary)
 
         {:ok, state}
       end
@@ -171,6 +175,27 @@ defmodule TrpgMaster.Campaign.Persistence do
         {:ok, []}
 
       {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  컨텍스트 요약 로그를 summary_log.jsonl에 추가한다.
+  """
+  def append_summary_log(campaign_id, summary_text) do
+    dir = campaign_dir(campaign_id)
+    File.mkdir_p(dir)
+    log_path = Path.join(dir, "summary_log.jsonl")
+
+    entry = Jason.encode!(%{
+      "timestamp" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "summary" => summary_text
+    })
+
+    case File.write(log_path, entry <> "\n", [:append]) do
+      :ok -> :ok
+      {:error, reason} ->
+        Logger.error("요약 로그 저장 실패 [#{campaign_id}]: #{inspect(reason)}")
         {:error, reason}
     end
   end
@@ -339,6 +364,21 @@ defmodule TrpgMaster.Campaign.Persistence do
       read_json(path)
     else
       {:ok, []}
+    end
+  end
+
+  defp save_context_summary(_dir, nil), do: :ok
+
+  defp save_context_summary(dir, summary) do
+    write_json(Path.join(dir, "context_summary.json"), %{"summary" => summary})
+  end
+
+  defp load_context_summary(dir) do
+    path = Path.join(dir, "context_summary.json")
+
+    case read_json(path) do
+      {:ok, %{"summary" => summary}} -> summary
+      _ -> nil
     end
   end
 

--- a/lib/trpg_master/campaign/server.ex
+++ b/lib/trpg_master/campaign/server.ex
@@ -94,8 +94,8 @@ defmodule TrpgMaster.Campaign.Server do
         session_number = estimate_session_number(state)
         Persistence.append_session_log(state, session_number, summary_text)
 
-        # 대화 히스토리 리셋 (캐릭터/NPC/퀘스트는 유지)
-        new_state = %{state | conversation_history: []}
+        # 대화 히스토리 및 컨텍스트 요약 리셋 (캐릭터/NPC/퀘스트는 유지)
+        new_state = %{state | conversation_history: [], context_summary: nil}
         Persistence.save_async(new_state)
 
         {:reply, {:ok, summary_text}, new_state}
@@ -117,7 +117,7 @@ defmodule TrpgMaster.Campaign.Server do
 
     system_prompt = PromptBuilder.build(state)
     tools = Tools.definitions(state.phase) ++ Tools.state_tool_definitions()
-    trimmed_history = PromptBuilder.build_messages(history)
+    trimmed_history = PromptBuilder.build_messages_with_summary(message, state.context_summary)
 
     # read_journal 도구가 현재 저널 데이터에 접근할 수 있도록 프로세스 딕셔너리에 저장
     Process.put(:journal_entries, state.journal_entries)
@@ -151,6 +151,22 @@ defmodule TrpgMaster.Campaign.Server do
           | conversation_history:
               state.conversation_history ++ [%{"role" => "assistant", "content" => result.text}]
         }
+
+        # 컨텍스트 요약 생성 (저비용 모델 사용)
+        state =
+          case generate_context_summary(state, message, result.text) do
+            {:ok, new_summary} ->
+              if state.context_summary do
+                Persistence.append_summary_log(state.id, state.context_summary)
+              end
+
+              Logger.info("컨텍스트 요약 갱신 [#{state.id}]")
+              %{state | context_summary: new_summary}
+
+            {:error, reason} ->
+              Logger.warning("컨텍스트 요약 생성 실패 [#{state.id}]: #{inspect(reason)}")
+              state
+          end
 
         Persistence.save_async(state)
 
@@ -216,6 +232,38 @@ defmodule TrpgMaster.Campaign.Server do
     recent_history = Enum.take(state.conversation_history, -20)
 
     case Client.chat(summary_prompt, recent_history, [], model: haiku_model, max_tokens: 1024) do
+      {:ok, result} -> {:ok, result.text}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp generate_context_summary(state, user_message, ai_response) do
+    haiku_model = summary_model_for(state.ai_model)
+
+    previous = state.context_summary || "(첫 번째 턴 — 이전 요약 없음)"
+    truncated_response = String.slice(ai_response, 0, 2000)
+
+    summary_prompt = """
+    당신은 TRPG 세션 기록 요약 도우미입니다.
+
+    ## 이전 요약
+    #{previous}
+
+    ## 최신 대화
+    플레이어: #{user_message}
+    DM: #{truncated_response}
+
+    ## 지시사항
+    위 정보를 하나의 간결한 요약으로 통합하세요 (최대 500자).
+    반드시 포함할 내용:
+    - 등장한 NPC들 (이름과 태도)
+    - 현재 진행 중인 퀘스트와 상태
+    - 현재 위치
+    - 최근 주요 사건이나 결정
+    불필요한 세부사항은 생략하고, 다음 턴에서 DM이 맥락을 파악하는 데 필요한 정보만 남기세요.
+    """
+
+    case Client.chat(summary_prompt, [], [], model: haiku_model, max_tokens: 512) do
       {:ok, result} -> {:ok, result.text}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/trpg_master/campaign/state.ex
+++ b/lib/trpg_master/campaign/state.ex
@@ -16,7 +16,8 @@ defmodule TrpgMaster.Campaign.State do
     turn_count: 0,
     mode: :adventure,
     journal_entries: [],
-    ai_model: nil
+    ai_model: nil,
+    context_summary: nil
   ]
 
   @doc """
@@ -37,7 +38,8 @@ defmodule TrpgMaster.Campaign.State do
       "character_names" => state.characters |> Enum.map(& &1["name"]) |> Enum.reject(&is_nil/1),
       "npc_names" => Map.keys(state.npcs),
       "journal_count" => length(state.journal_entries),
-      "ai_model" => state.ai_model
+      "ai_model" => state.ai_model,
+      "context_summary" => state.context_summary
     }
   end
 
@@ -55,7 +57,8 @@ defmodule TrpgMaster.Campaign.State do
       turn_count: summary["turn_count"] || 0,
       mode: safe_atom(summary["mode"], :adventure),
       combat_state: summary["combat_state"],
-      ai_model: summary["ai_model"]
+      ai_model: summary["ai_model"],
+      context_summary: summary["context_summary"]
       # journal_entries는 Persistence.load에서 별도로 로드한다
     }
   end

--- a/lib/trpg_master_web/components/game_components.ex
+++ b/lib/trpg_master_web/components/game_components.ex
@@ -51,6 +51,22 @@ defmodule TrpgMasterWeb.GameComponents do
   end
 
   @doc """
+  도구 호출 결과 알림 컴포넌트.
+  상태 변경 도구(NPC 등록, 퀘스트 갱신, 위치 변경 등) 실행 시 채팅에 표시.
+  """
+  attr :tool_name, :string, required: true
+  attr :message, :string, required: true
+
+  def tool_narration(assigns) do
+    ~H"""
+    <div class="message tool-narration-message">
+      <span class="tool-icon"><%= tool_icon(@tool_name) %></span>
+      <span class="tool-text"><%= @message %></span>
+    </div>
+    """
+  end
+
+  @doc """
   시스템 메시지 컴포넌트.
   """
   attr :text, :string, required: true
@@ -153,6 +169,15 @@ defmodule TrpgMasterWeb.GameComponents do
       ""
     end
   end
+
+  defp tool_icon("register_npc"), do: "📋"
+  defp tool_icon("update_quest"), do: "📜"
+  defp tool_icon("set_location"), do: "📍"
+  defp tool_icon("start_combat"), do: "⚔️"
+  defp tool_icon("end_combat"), do: "🏁"
+  defp tool_icon("update_character"), do: "👤"
+  defp tool_icon("write_journal"), do: "📝"
+  defp tool_icon(_), do: "🔧"
 
   defp spell_slot_total(character) do
     slots = character["spell_slots"] || %{}

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -177,6 +177,10 @@ defmodule TrpgMasterWeb.CampaignLive do
                   acc ++ [%{type: :dice, result: dice_result}]
                 end
 
+              %{tool: tool_name, result: %{"status" => "ok", "message" => message}}
+              when tool_name in ~w(register_npc update_quest set_location start_combat end_combat update_character write_journal) ->
+                acc ++ [%{type: :tool_narration, tool_name: tool_name, message: message}]
+
               _ ->
                 acc
             end
@@ -313,6 +317,8 @@ defmodule TrpgMasterWeb.CampaignLive do
               <.player_message text={msg.text} name={if @character, do: @character["name"] || "플레이어", else: "플레이어"} />
             <% :dice -> %>
               <.dice_result result={msg.result} />
+            <% :tool_narration -> %>
+              <.tool_narration tool_name={msg.tool_name} message={msg.message} />
             <% :system -> %>
               <.system_message text={msg.text} />
           <% end %>

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -144,6 +144,28 @@ html, body {
   flex-wrap: wrap;
 }
 
+.tool-narration-message {
+  background: #1a2a3a;
+  border: 1px solid #2a4a6a;
+  align-self: center;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--accent-blue);
+}
+
+.tool-narration-message .tool-icon {
+  font-size: 1rem;
+}
+
+.tool-narration-message .tool-text {
+  color: var(--text-secondary);
+}
+
 .system-message {
   background: var(--system-bg);
   align-self: center;


### PR DESCRIPTION
## Summary
Implements automatic context summarization to reduce token consumption in long TRPG campaigns. Instead of maintaining the full conversation history, the system now generates and maintains a concise summary of key information (NPCs, quests, location, recent events) that is passed to the AI model alongside the current message.

## Key Changes

- **Context Summary Generation**: Added `generate_context_summary/3` function that uses a lightweight model (Haiku) to create summaries after each turn, including previous summaries, latest player/DM exchange, and instructions to preserve essential campaign context.

- **Message Building with Summary**: Replaced full history with summary-based approach via new `build_messages_with_summary/2` function that passes the context summary plus current message instead of entire conversation history.

- **State Management**: 
  - Added `context_summary` field to campaign state
  - Reset context summary on session end (along with conversation history)
  - Persist and load context summary from `context_summary.json`

- **Persistence Layer**: 
  - Added `save_context_summary/2` and `load_context_summary/1` helpers
  - Added `append_summary_log/2` to maintain historical record of summaries in `summary_log.jsonl`

- **UI Enhancements**:
  - New `tool_narration/2` component to display tool execution results (NPC registration, quest updates, location changes, etc.)
  - Added styling for tool narration messages with icons and secondary text color
  - Integrated tool narration display in campaign live view

## Implementation Details

- Context summaries are generated using a cost-effective model variant (determined by `summary_model_for/1`)
- Summaries are truncated to 2000 characters before processing and limited to 500 characters in output
- Previous summaries are logged before being replaced, creating an audit trail
- Tool execution results are now visually distinguished in chat with emoji icons and styled containers
- Gracefully handles missing summaries on first turn and summary generation failures

https://claude.ai/code/session_01Tyt2KasTUew3fDCZomf6S5