### PR TITLE
Add favicon and AI provider icons to chat header

### DIFF
--- a/lib/trpg_master_web/components/layouts/root.html.heex
+++ b/lib/trpg_master_web/components/layouts/root.html.heex
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <title>AI TRPG Master</title>
+    <link rel="icon" type="image/svg+xml" href={~p"/images/favicon.svg"} />
+    <link rel="alternate icon" type="image/x-icon" href={~p"/favicon.ico"} />
     <link rel="stylesheet" href={~p"/css/app.css"} />
   </head>
   <body>

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -255,7 +255,7 @@ defmodule TrpgMasterWeb.CampaignLive do
         <div class="header-right">
           <span class="mode-badge"><%= phase_label(@phase) %></span>
           <button phx-click="toggle_model_selector" class="dm-select-btn" title="DM 선택">
-            🤖 <%= model_short_name(@ai_model) %>
+            <%= provider_icon(@ai_model) %>
           </button>
           <button phx-click="toggle_mode" class={"mode-toggle #{if @mode == :debug, do: "mode-debug", else: "mode-adventure"}"} title={if @mode == :adventure, do: "디버그 모드로 전환", else: "모험 모드로 전환"}>
             <%= if @mode == :adventure do %>🎭<% else %>🔧<% end %>
@@ -407,10 +407,44 @@ defmodule TrpgMasterWeb.CampaignLive do
   defp phase_label(:rest), do: "휴식"
   defp phase_label(_), do: "모험"
 
-  defp model_short_name(model_id) do
-    case Models.find(model_id) do
-      nil -> model_id || "선택"
-      model -> model.name
-    end
+  defp provider_icon(model_id) do
+    svg =
+      case Models.provider_for(model_id) do
+        :anthropic ->
+          # Anthropic / Claude — simplified "A" lettermark, coral colour
+          """
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Claude">
+            <path d="M13.83 3.52h-3.62L5.08 20.48h3.46l1.07-3.04h4.78l1.07 3.04h3.46L13.83 3.52zm-3.33 11.25 1.57-4.47 1.57 4.47H10.5z" fill="#D97757"/>
+          </svg>
+          """
+
+        :openai ->
+          # OpenAI / GPT — four-pointed star polygon, green
+          """
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="GPT">
+            <path d="M22.28 9.82a5.98 5.98 0 0 0-.52-4.91 6.05 6.05 0 0 0-6.51-2.9A6.07 6.07 0 0 0 4.98 4.18a5.98 5.98 0 0 0-3.99 2.9 6.05 6.05 0 0 0 .74 7.1 5.98 5.98 0 0 0 .51 4.91 6.05 6.05 0 0 0 6.51 2.9A5.98 5.98 0 0 0 13.26 24a6.06 6.06 0 0 0 5.77-4.21 5.99 5.99 0 0 0 4-2.9 6.06 6.06 0 0 0-.75-7.07zM13.26 22.5a4.48 4.48 0 0 1-2.88-1.04l.14-.08 4.78-2.76a.79.79 0 0 0 .4-.68V11.2l2.02 1.17a.07.07 0 0 1 .04.05v5.58a4.5 4.5 0 0 1-4.5 4.5zM3.6 18.37a4.47 4.47 0 0 1-.53-3.01l.14.08 4.78 2.76a.77.77 0 0 0 .78 0l5.84-3.37v2.33a.08.08 0 0 1-.03.06L9.74 19.95A4.5 4.5 0 0 1 3.6 18.37zM2.34 7.9a4.49 4.49 0 0 1 2.37-1.97v5.65a.77.77 0 0 0 .39.68l5.81 3.35-2.02 1.17a.08.08 0 0 1-.07 0L3.55 13.9A4.5 4.5 0 0 1 2.34 7.89zm16.6 3.86-5.84-3.37 2.02-1.17a.08.08 0 0 1 .07 0l4.83 2.79a4.49 4.49 0 0 1-.68 8.1V12.44a.79.79 0 0 0-.4-.68zm2.01-3.02-.14-.09-4.77-2.78a.78.78 0 0 0-.79 0L9.41 9.23V6.9a.07.07 0 0 1 .03-.06l4.83-2.79a4.5 4.5 0 0 1 6.68 4.66zM8.31 12.86 6.29 11.7a.08.08 0 0 1-.04-.06V6.07a4.5 4.5 0 0 1 7.38-3.45l-.14.08-4.78 2.76a.79.79 0 0 0-.4.68v6.72zm1.1-2.37 2.6-1.5 2.61 1.5v3L12 15l-2.6-1.5V10.5z" fill="#10A37F"/>
+          </svg>
+          """
+
+        :gemini ->
+          # Google Gemini — four-pointed star, blue-to-purple gradient
+          """
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Gemini">
+            <defs>
+              <linearGradient id="gemini-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#4285F4"/>
+                <stop offset="100%" stop-color="#8B5CF6"/>
+              </linearGradient>
+            </defs>
+            <path d="M12 24A14.3 14.3 0 0 1 0 12 14.3 14.3 0 0 1 12 0a14.3 14.3 0 0 1 12 12 14.3 14.3 0 0 1-12 12z" fill="url(#gemini-grad)"/>
+            <path d="M12 22A12.3 12.3 0 0 0 2 12 12.3 12.3 0 0 0 12 2a12.3 12.3 0 0 0 10 10 12.3 12.3 0 0 0-10 10z" fill="white"/>
+          </svg>
+          """
+
+        _ ->
+          "<span style=\"font-size:1.1rem\">🤖</span>"
+      end
+
+    Phoenix.HTML.raw(svg)
   end
 end

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -910,18 +910,25 @@ html, body {
 /* ── DM 선택 버튼 & 모달 ────────────────────────────────────────────── */
 
 .dm-select-btn {
-  padding: 0.3rem 0.6rem;
+  padding: 0.25rem;
+  width: 34px;
+  height: 34px;
   border-radius: 8px;
   border: 1px solid var(--border-color);
   background: transparent;
   color: var(--text-secondary);
-  font-size: 0.85rem;
   cursor: pointer;
   transition: all 0.2s;
-  white-space: nowrap;
-  max-width: 130px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.dm-select-btn svg {
+  width: 22px;
+  height: 22px;
+  display: block;
 }
 
 .dm-select-btn:hover {

--- a/priv/static/images/favicon.svg
+++ b/priv/static/images/favicon.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Parchment background -->
+  <rect width="32" height="32" rx="5" fill="#F5E6B0"/>
+  <rect x="1" y="1" width="30" height="30" rx="4" fill="#F0DC9A" opacity="0.6"/>
+
+  <!-- Parchment text lines -->
+  <line x1="4" y1="22" x2="18" y2="22" stroke="#8B7355" stroke-width="1" stroke-linecap="round" opacity="0.5"/>
+  <line x1="4" y1="25" x2="14" y2="25" stroke="#8B7355" stroke-width="1" stroke-linecap="round" opacity="0.4"/>
+
+  <!-- Quill feather body -->
+  <path d="M28 2 C24 4, 18 8, 14 14 C12 17, 11 20, 11 22 C13 20, 16 17, 19 14 C22 11, 26 7, 28 2Z" fill="#E8D080"/>
+  <path d="M28 2 C25 5, 20 9, 16 15 C14 18, 13 21, 12 23 C14 21, 17 18, 20 15 C23 12, 26 7, 28 2Z" fill="#F0E090" opacity="0.7"/>
+  <path d="M28 2 C26 4, 22 7, 18 12 C16 15, 14 18, 13 20" stroke="#C8A840" stroke-width="0.5" fill="none" opacity="0.8"/>
+
+  <!-- Quill spine -->
+  <path d="M28 2 L12 22" stroke="#B89A30" stroke-width="0.8" stroke-linecap="round"/>
+
+  <!-- Quill nib -->
+  <path d="M12 22 L9 27 L14 24 Z" fill="#2C1A0E"/>
+  <path d="M11 24 L10 27" stroke="#1a0e06" stroke-width="0.8" stroke-linecap="round"/>
+
+  <!-- Animated ink writing -->
+  <g>
+    <!-- First ink stroke -->
+    <path d="M10 27 Q7 26 5 25" stroke="#1A1A3E" stroke-width="1.2" stroke-linecap="round" fill="none"
+      stroke-dasharray="8" stroke-dashoffset="8">
+      <animate attributeName="stroke-dashoffset" values="8;0;0;8" dur="2.5s" repeatCount="indefinite" begin="0s"/>
+    </path>
+    <!-- Second ink stroke -->
+    <path d="M4 22 Q8 22 12 22" stroke="#1A1A3E" stroke-width="1.2" stroke-linecap="round" fill="none"
+      stroke-dasharray="10" stroke-dashoffset="10">
+      <animate attributeName="stroke-dashoffset" values="10;0;0;10" dur="2.5s" repeatCount="indefinite" begin="0.6s"/>
+    </path>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- 양피지 위에 깃털 펜이 자동으로 글을 쓰는 애니메이션 SVG 파비콘 추가
- 채팅 상단바 DM 선택 버튼의 모델 이름 텍스트를 AI 프로바이더 브랜드 아이콘으로 교체
  - Claude (Anthropic): 산호색 "A" 레터마크
  - GPT (OpenAI): 초록색 OpenAI 폴리곤
  - Gemini (Google): 파란-보라 그라데이언트 별 모양
- dm-select-btn CSS를 아이콘 전용 정사각형 버튼으로 조정

## Test plan
- [ ] 브라우저 탭에 깃털 펜 파비콘 표시 확인
- [ ] 각 AI 모델 선택 시 해당 브랜드 아이콘 표시 확인
- [ ] 모델 이름 텍스트가 버튼에 더 이상 표시되지 않는지 확인
- [ ] 모델 선택 모달은 기존과 동일하게 동작하는지 확인