### PR TITLE
fix: 전투 합성 메시지가 채팅 히스토리에 노출되는 버그 수정

### DIFF
--- a/lib/trpg_master/ai/prompt_builder.ex
+++ b/lib/trpg_master/ai/prompt_builder.ex
@@ -219,7 +219,10 @@ defmodule TrpgMaster.AI.PromptBuilder do
     # 현재 라운드의 모든 메시지 (current_round_start_index부터 끝까지)
     # 플레이어 액션, 적 턴 트리거, 라운드 정리 트리거 모두 포함
     # 이전 라운드들은 combat_history_summary가 시스템 프롬프트에서 커버
-    current_round_msgs = Enum.drop(state.combat_history, state.current_round_start_index)
+    current_round_msgs =
+      state.combat_history
+      |> Enum.drop(state.current_round_start_index)
+      |> Enum.map(&Map.delete(&1, "synthetic"))
 
     ensure_valid_turn_order(exploration_recent) ++ current_round_msgs
   end

--- a/lib/trpg_master/campaign/server.ex
+++ b/lib/trpg_master/campaign/server.ex
@@ -280,7 +280,7 @@ defmodule TrpgMaster.Campaign.Server do
   defp handle_enemy_group_turns(state, results, [], tools, model_opts) do
     # 모든 적 그룹 처리 완료 → 라운드 정리 API 호출
     round_trigger = "이번 라운드가 끝났습니다. 라운드를 정리하고 플레이어에게 다음 행동을 물어보세요."
-    state = %{state | combat_history: state.combat_history ++ [%{"role" => "user", "content" => round_trigger}]}
+    state = %{state | combat_history: state.combat_history ++ [%{"role" => "user", "content" => round_trigger, "synthetic" => true}]}
 
     system_prompt = PromptBuilder.build(state, combat_phase: :round_summary)
     trimmed_history = PromptBuilder.build_turn_messages(state, round_trigger)
@@ -342,7 +342,7 @@ defmodule TrpgMaster.Campaign.Server do
     combat_phase = {:enemy_turn, enemy_name, is_last_group}
 
     # 트리거 메시지를 combat_history에 user 메시지로 저장 (라운드 전체 히스토리 유지)
-    state = %{state | combat_history: state.combat_history ++ [%{"role" => "user", "content" => trigger_msg}]}
+    state = %{state | combat_history: state.combat_history ++ [%{"role" => "user", "content" => trigger_msg, "synthetic" => true}]}
 
     system_prompt = PromptBuilder.build(state, combat_phase: combat_phase)
     trimmed_history = PromptBuilder.build_turn_messages(state, trigger_msg, combat_phase: combat_phase)

--- a/lib/trpg_master_web/live/campaign_live.ex
+++ b/lib/trpg_master_web/live/campaign_live.ex
@@ -704,6 +704,9 @@ defmodule TrpgMasterWeb.CampaignLive do
     conversation_history
     |> Enum.reduce([], fn msg, acc ->
       case msg do
+        %{"role" => "user", "synthetic" => true} ->
+          acc
+
         %{"role" => "user", "content" => content} when is_binary(content) ->
           acc ++ [%{type: :player, text: content}]
 


### PR DESCRIPTION
적 턴 트리거/라운드 정리 등 서버가 자동 생성하는 user 메시지에
"synthetic" 플래그를 추가하고, 히스토리 표시 시 필터링하여
플레이어가 치지 않은 메시지가 노출되지 않도록 함.